### PR TITLE
Do not fail on HTTP redirects, but do not follow them either, close #22.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/httpchecker.go
+++ b/httpchecker.go
@@ -174,7 +174,7 @@ var DefaultHTTPClient = &http.Client{
 		ResponseHeaderTimeout: 5 * time.Second,
 	},
 	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		return fmt.Errorf("no redirects allowed")
+		return http.ErrUseLastResponse
 	},
 	Timeout: 10 * time.Second,
 }


### PR DESCRIPTION
This pull request will allow the HTTP status of redirects to be checked, without following the redirect.

This way, a redirect can be considered healthy, by configuring `"up_status": 302` or `"up_status": 301` in checkup.json.

For unchanged checkup.json configurations, redirects will still fail as before (as they are not HTTP status 2xx, the default expected).
