### PR TITLE
Colors and exit status

### DIFF
--- a/checkup.go
+++ b/checkup.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/fatih/color"
 )
 
 // Checkup performs a routine checkup on endpoints or
@@ -455,7 +457,16 @@ func (r Result) String() string {
 	s += fmt.Sprintf("     Median: %s\n", stats.Median)
 	s += fmt.Sprintf("       Mean: %s\n", stats.Mean)
 	s += fmt.Sprintf("        All: %v\n", r.Times)
-	s += fmt.Sprintf(" Assessment: %v\n", r.Status())
+	statusLine := fmt.Sprintf(" Assessment: %v\n", r.Status())
+	switch r.Status() {
+	case Healthy:
+		statusLine = color.GreenString(statusLine)
+	case Degraded:
+		statusLine = color.YellowString(statusLine)
+	case Down:
+		statusLine = color.RedString(statusLine)
+	}
+	s += statusLine
 	return s
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ a single checkup and print results to stdout. To
 store the results of the check, use --store.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		allHealthy := true
 		c := loadCheckup()
 
 		if storeResults {
@@ -54,6 +55,13 @@ store the results of the check, use --store.`,
 
 		for _, result := range results {
 			fmt.Println(result)
+			if !result.Healthy {
+				allHealthy = false
+			}
+		}
+
+		if !allHealthy {
+			os.Exit(1)
 		}
 	},
 }


### PR DESCRIPTION
Quick PR to add colors to `checkup` status CLI message and exit with status 1 when not all checks are healthy (for use in CI scripts):

![image](https://cloud.githubusercontent.com/assets/1646931/18330872/f004da96-750f-11e6-8e82-f2be06c5b22b.png)

