### PR TITLE
Add support for HTTP Headers

### DIFF
--- a/httpchecker.go
+++ b/httpchecker.go
@@ -54,6 +54,23 @@ type HTTPChecker struct {
 	// requests. If not set, DefaultHTTPClient is
 	// used.
 	Client *http.Client `json:"-"`
+
+	// Headers is a slice of Headerthat contains the
+	// name and value for the header.
+	// Default is no additional headers are sent.
+	Headers []Header `json:"headers,omitempty"`
+}
+
+// Header represents a single HTTP header that can be
+// added to a request. Default is no headers
+type Header struct {
+	// Name is for the name of the header.
+	// ex: Content-Type
+	Name string `json:"name"`
+
+	// Value is the value of the header.
+	// ex: application/json
+	Value string `json:"value"`
 }
 
 // Check performs checks using c according to its configuration.
@@ -73,6 +90,12 @@ func (c HTTPChecker) Check() (Result, error) {
 	req, err := http.NewRequest("GET", c.URL, nil)
 	if err != nil {
 		return result, err
+	}
+
+	if c.Headers != nil {
+		for _, header := range c.Headers {
+			req.Header.Add(header.Name, header.Value)
+		}
 	}
 
 	result.Times = c.doChecks(req)

--- a/httpchecker.go
+++ b/httpchecker.go
@@ -55,22 +55,9 @@ type HTTPChecker struct {
 	// used.
 	Client *http.Client `json:"-"`
 
-	// Headers is a slice of Headerthat contains the
-	// name and value for the header.
-	// Default is no additional headers are sent.
-	Headers []Header `json:"headers,omitempty"`
-}
-
-// Header represents a single HTTP header that can be
-// added to a request. Default is no headers
-type Header struct {
-	// Name is for the name of the header.
-	// ex: Content-Type
-	Name string `json:"name"`
-
-	// Value is the value of the header.
-	// ex: application/json
-	Value string `json:"value"`
+	// Headers contains headers to added to the request
+	// that is sent for the check
+	Headers http.Header `json:"headers,omitempty"`
 }
 
 // Check performs checks using c according to its configuration.
@@ -93,8 +80,8 @@ func (c HTTPChecker) Check() (Result, error) {
 	}
 
 	if c.Headers != nil {
-		for _, header := range c.Headers {
-			req.Header.Add(header.Name, header.Value)
+		for key, header := range c.Headers {
+			req.Header.Add(key, strings.Join(header, ", "))
 		}
 	}
 

--- a/httpchecker_test.go
+++ b/httpchecker_test.go
@@ -104,8 +104,8 @@ func TestHTTPChecker(t *testing.T) {
 	}
 
 	// Test with a Header
-	hc.Headers = []Header{
-		{Name: "X-Checkup", Value: "Echo"},
+	hc.Headers = http.Header{
+		"X-Checkup": []string{"Echo"},
 	}
 	hc.MustContain = "Echo"
 	hc.ThresholdRTT = 0

--- a/httpchecker_test.go
+++ b/httpchecker_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestHTTPChecker(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Checkup", r.Header.Get("X-Checkup"))
 		fmt.Fprintln(w, "I'm up")
 	}))
 	endpt := "http://" + srv.Listener.Addr().String()
@@ -94,6 +95,20 @@ func TestHTTPChecker(t *testing.T) {
 	}
 
 	hc.MustNotContain = "I"
+	result, err = hc.Check()
+	if err != nil {
+		t.Errorf("Didn't expect an error: %v", err)
+	}
+	if got, want := result.Down, true; got != want {
+		t.Errorf("Expected result.Down=%v, got %v", want, got)
+	}
+
+	// Test with a Header
+	hc.Headers = []Header{
+		{Name: "X-Checkup", Value: "Echo"},
+	}
+	hc.MustContain = "Echo"
+	hc.ThresholdRTT = 0
 	result, err = hc.Check()
 	if err != nil {
 		t.Errorf("Didn't expect an error: %v", err)


### PR DESCRIPTION
This adds support for adding customer request headers to HTTPChecker. It adds a new field Headers to the HTTPChecker type. The Headers field is a slice of type Header, which has fields for the name and value of the header.