### PR TITLE
documentation: added docker parameter to fix build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Linux binary:
 ```bash
 git clone git@github.com:sourcegraph/checkup.git
 cd checkup
-docker run --rm \ 
+docker run --net=host --rm \ 
 -v `pwd`:/project \ 
 -w /project golang bash \ 
 -c "cd cmd/checkup; go get -v -d; go build -v -ldflags '-s' -o ../../checkup"


### PR DESCRIPTION
On Ubuntu 16.04. with docker 1.11.1 there is an issue accessing github.com from docker.

Fixes #39 
