### PR TITLE
statuspage: .innerHTML undefined on dom.lastcheck, .remove() undefined

### DIFF
--- a/statuspage/js/statuspage.js
+++ b/statuspage/js/statuspage.js
@@ -1,5 +1,13 @@
 // config.js must be included BEFORE this file!
 
+// IE 11 Polyfill for .remove()
+if (!('remove' in Element.prototype)) {
+    Element.prototype.remove = function() {
+        if (this.parentNode) {
+            this.parentNode.removeChild(this);
+        }
+    };
+}
 // Configure access to storage
 checkup.storage.setup(checkup.config.storage);
 
@@ -15,12 +23,12 @@ document.addEventListener('DOMContentLoaded', function() {
 	checkup.dom.checkcount = document.getElementById("info-checkcount");
 	checkup.dom.lastcheck = document.getElementById("info-lastcheck");
 	checkup.dom.timeline = document.getElementById("timeline");
+	// Immediately begin downloading check files, and keep page updated
+	checkup.storage.getChecksWithin(checkup.config.timeframe, processNewCheckFile, allCheckFilesLoaded);
 
 	if (!checkup.graphsMade) makeGraphs();
 }, false);
 
-// Immediately begin downloading check files, and keep page updated 
-checkup.storage.getChecksWithin(checkup.config.timeframe, processNewCheckFile, allCheckFilesLoaded);
 setInterval(function() {
 	checkup.storage.getNewChecks(processNewCheckFile, allCheckFilesLoaded);
 }, checkup.config.refresh_interval * 1000);


### PR DESCRIPTION
Changes on the front-end only, compatibility with IE 11.
For some reason IE 11 is able to get to checkup.dom.lastcheck.innerHTML before DOMContentLoaded event. Moving when getChecksWithin is invoked remedies that situation.
Performance doesn't seem to be affected.
http://caniuse.com/#search=remove ChildNode.remove() not compatible with IE 11.