### PR TITLE
allow empty S3 creds for config from EC2 metadata

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -34,10 +34,14 @@ func (s S3) Store(results []Result) error {
 	if err != nil {
 		return err
 	}
-	svc := newS3(session.New(), &aws.Config{
-		Credentials: credentials.NewStaticCredentials(s.AccessKeyID, s.SecretAccessKey, ""),
-		Region:      &s.Region,
-	})
+	config := &aws.Config{
+		Region: &s.Region,
+	}
+	if s.AccessKeyID != "" && s.SecretAccessKey != "" {
+		config.Credentials = credentials.NewStaticCredentials(s.AccessKeyID, s.SecretAccessKey, "")
+	}
+
+	svc := newS3(session.New(), config)
 	params := &s3.PutObjectInput{
 		Bucket: &s.Bucket,
 		Key:    GenerateFilename(),
@@ -53,10 +57,14 @@ func (s S3) Maintain() error {
 		return nil
 	}
 
-	svc := newS3(session.New(), &aws.Config{
-		Credentials: credentials.NewStaticCredentials(s.AccessKeyID, s.SecretAccessKey, ""),
-		Region:      &s.Region,
-	})
+	config := &aws.Config{
+		Region: &s.Region,
+	}
+	if s.AccessKeyID != "" && s.SecretAccessKey != "" {
+		config.Credentials = credentials.NewStaticCredentials(s.AccessKeyID, s.SecretAccessKey, "")
+	}
+
+	svc := newS3(session.New(), config)
 
 	var marker *string
 	for {


### PR DESCRIPTION
This change only configures credentials for the S3 client if AcccessKeyID and SecretAccessKey have both been set in the config. Otherwise it falls back to the default credential lookup mechanism in the AWS SDK which tries to aquire credentials from environment variables or EC2 metadata. This allows checkup to be used without providing explicit credentials on an EC2 machine with an appropriate instance profile.