### PR TITLE
Add GitHub storage provider

### DIFF
--- a/checkup.go
+++ b/checkup.go
@@ -204,6 +204,8 @@ func (c Checkup) MarshalJSON() ([]byte, error) {
 		}
 		var providerName string
 		switch c.Storage.(type) {
+		case GitHub:
+			providerName = "github"
 		case S3:
 			providerName = "s3"
 		case FS:
@@ -321,6 +323,13 @@ func (c *Checkup) UnmarshalJSON(b []byte) error {
 			c.Storage = storage
 		case "fs":
 			var storage FS
+			err = json.Unmarshal(raw.Storage, &storage)
+			if err != nil {
+				return err
+			}
+			c.Storage = storage
+		case "github":
+			var storage GitHub
 			err = json.Unmarshal(raw.Storage, &storage)
 			if err != nil {
 				return err

--- a/checkup.go
+++ b/checkup.go
@@ -204,7 +204,7 @@ func (c Checkup) MarshalJSON() ([]byte, error) {
 		}
 		var providerName string
 		switch c.Storage.(type) {
-		case GitHub:
+		case *GitHub:
 			providerName = "github"
 		case S3:
 			providerName = "s3"
@@ -329,8 +329,8 @@ func (c *Checkup) UnmarshalJSON(b []byte) error {
 			}
 			c.Storage = storage
 		case "github":
-			var storage GitHub
-			err = json.Unmarshal(raw.Storage, &storage)
+			var storage *GitHub
+			err = json.Unmarshal(raw.Storage, storage)
 			if err != nil {
 				return err
 			}

--- a/checkup.go
+++ b/checkup.go
@@ -329,7 +329,7 @@ func (c *Checkup) UnmarshalJSON(b []byte) error {
 			}
 			c.Storage = storage
 		case "github":
-			var storage *GitHub
+			storage := &GitHub{}
 			err = json.Unmarshal(raw.Storage, storage)
 			if err != nil {
 				return err

--- a/github.go
+++ b/github.go
@@ -150,9 +150,8 @@ func (gh *GitHub) writeFile(filename string, sha string, contents []byte) error 
 	return err
 }
 
-// deleteFile deletes a file from a Git tree and returns the new SHA for the ref
-// and any applicable errors. If an error occurs, the input SHA is returned along
-// with the error.
+// deleteFile deletes a file from a Git tree and returns any applicable errors.
+// If an empty SHA is passed as an argument, errFileNotFound is returned.
 func (gh *GitHub) deleteFile(filename string, sha string) error {
 	if err := gh.ensureClient(); err != nil {
 		return err

--- a/github.go
+++ b/github.go
@@ -52,7 +52,7 @@ func (gh *GitHub) ensureClient() error {
 	return nil
 }
 
-func (gh GitHub) fullPathName(filename string) string {
+func (gh *GitHub) fullPathName(filename string) string {
 	if strings.HasPrefix(filename, gh.Dir) {
 		return filename
 	} else {
@@ -60,7 +60,7 @@ func (gh GitHub) fullPathName(filename string) string {
 	}
 }
 
-func (gh GitHub) readFile(filename string) ([]byte, string, error) {
+func (gh *GitHub) readFile(filename string) ([]byte, string, error) {
 	if err := gh.ensureClient(); err != nil {
 		return nil, "", err
 	}
@@ -83,7 +83,7 @@ func (gh GitHub) readFile(filename string) ([]byte, string, error) {
 	return []byte(decoded), *contents.SHA, err
 }
 
-func (gh GitHub) writeFile(filename string, sha string, contents []byte) error {
+func (gh *GitHub) writeFile(filename string, sha string, contents []byte) error {
 	if err := gh.ensureClient(); err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (gh GitHub) writeFile(filename string, sha string, contents []byte) error {
 // deleteFile deletes a file from a Git tree and returns the new SHA for the ref
 // and any applicable errors. If an error occurs, the input SHA is returned along
 // with the error.
-func (gh GitHub) deleteFile(filename string, sha string) (string, error) {
+func (gh *GitHub) deleteFile(filename string, sha string) (string, error) {
 	if err := gh.ensureClient(); err != nil {
 		return "", err
 	}
@@ -157,7 +157,7 @@ func (gh GitHub) deleteFile(filename string, sha string) (string, error) {
 	return *commit.Commit.SHA, nil
 }
 
-func (gh GitHub) readIndex() (map[string]int64, string, error) {
+func (gh *GitHub) readIndex() (map[string]int64, string, error) {
 	index := map[string]int64{}
 
 	contents, sha, err := gh.readFile(indexName)
@@ -172,7 +172,7 @@ func (gh GitHub) readIndex() (map[string]int64, string, error) {
 	return index, sha, err
 }
 
-func (gh GitHub) writeIndex(index map[string]int64, sha string) error {
+func (gh *GitHub) writeIndex(index map[string]int64, sha string) error {
 	contents, err := json.Marshal(index)
 	if err != nil {
 		return err
@@ -182,7 +182,7 @@ func (gh GitHub) writeIndex(index map[string]int64, sha string) error {
 }
 
 // Store stores results on filesystem according to the configuration in fs.
-func (gh GitHub) Store(results []Result) error {
+func (gh *GitHub) Store(results []Result) error {
 	// Write results to a new file
 	name := *GenerateFilename()
 	contents, err := json.Marshal(results)
@@ -207,7 +207,7 @@ func (gh GitHub) Store(results []Result) error {
 }
 
 // Maintain deletes check files that are older than fs.CheckExpiry.
-func (gh GitHub) Maintain() error {
+func (gh *GitHub) Maintain() error {
 	if gh.CheckExpiry == 0 {
 		return nil
 	}

--- a/github.go
+++ b/github.go
@@ -16,13 +16,31 @@ var errFileNotFound = fmt.Errorf("file not found on github")
 
 // GitHub is a way to store checkup results in a GitHub repository.
 type GitHub struct {
-	AccessToken     string `json:"access_token"`
+	// AccessToken is the API token used to authenticate with GitHub (required).
+	AccessToken string `json:"access_token"`
+
+	// RepositoryOwner is the account which owns the repository on GitHub (required).
+	// For https://github.com/octocat/kit, the owner is "octocat".
 	RepositoryOwner string `json:"repository_owner"`
-	RepositoryName  string `json:"repository_name"`
-	CommitterName   string `json:"committer_name"`
-	CommitterEmail  string `json:"committer_email"`
-	Branch          string `json:"branch"`
-	Dir             string `json:"dir"`
+
+	// RepositoryName is the name of the repository on GitHub (required).
+	// For https://github.com/octocat/kit, the name is "kit".
+	RepositoryName string `json:"repository_name"`
+
+	// CommitterName is the display name of the user corresponding to the AccessToken (required).
+	// If the AccessToken is for user @octocat, then this might be "Mona Lisa," her name.
+	CommitterName string `json:"committer_name"`
+
+	// CommitterEmail is the email address of the user corresponding to the AccessToken (required).
+	// If the AccessToken is for user @octocat, then this might be "mona@github.com".
+	CommitterEmail string `json:"committer_email"`
+
+	// Branch is the git branch to store the files to (required).
+	Branch string `json:"branch"`
+
+	// Dir is the subdirectory in the Git tree in which to store the files (required).
+	// For example, to write to the directory "updates" in the Git repo, this should be "updates".
+	Dir string `json:"dir"`
 
 	// Check files older than CheckExpiry will be
 	// deleted on calls to Maintain(). If this is

--- a/github.go
+++ b/github.go
@@ -30,7 +30,7 @@ type GitHub struct {
 	// deleted.
 	CheckExpiry time.Duration `json:"check_expiry,omitempty"`
 
-	client *github.Client
+	client *github.Client `json:"-"`
 }
 
 func (gh *GitHub) ensureClient() error {

--- a/github.go
+++ b/github.go
@@ -1,0 +1,205 @@
+package checkup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/github"
+)
+
+// GitHub is a way to store checkup results in a GitHub repository.
+type GitHub struct {
+	AccessToken     string `json:"access_token"`
+	RepositoryOwner string `json:"repository_owner"`
+	RepositoryName  string `json:"repository_name"`
+	CommitterName   string `json:"committer_name"`
+	CommitterEmail  string `json:"committer_email"`
+	Branch          string `json:"branch"`
+	Dir             string `json:"dir"`
+
+	// Check files older than CheckExpiry will be
+	// deleted on calls to Maintain(). If this is
+	// the zero value, no old check files will be
+	// deleted.
+	CheckExpiry time.Duration `json:"check_expiry,omitempty"`
+
+	client *github.Client
+}
+
+func (gh GitHub) fullPathName(filename string) string {
+	if strings.HasPrefix(filename, gh.Dir) {
+		return filename
+	} else {
+		return filepath.Join(gh.Dir, filename)
+	}
+}
+
+func (gh GitHub) readFile(filename string) ([]byte, string, error) {
+	contents, _, _, err := gh.client.Repositories.GetContents(
+		context.Background(),
+		gh.RepositoryOwner,
+		gh.RepositoryName,
+		gh.fullPathName(filename),
+		&github.RepositoryContentGetOptions{Ref: "heads/" + gh.Branch},
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	decoded, err := contents.GetContent()
+	return []byte(decoded), *contents.SHA, err
+}
+
+func (gh GitHub) writeFile(filename string, sha string, contents []byte) error {
+	var err error
+	var writeFunc func(context.Context, string, string, string, *github.RepositoryContentFileOptions) (*github.RepositoryContentResponse, *github.Response, error)
+	opts := &github.RepositoryContentFileOptions{
+		Message: github.String(fmt.Sprintf("[checkup] store %s [ci skip]", filename)),
+		Content: contents,
+		Committer: &github.CommitAuthor{
+			Name:  &gh.CommitterName,
+			Email: &gh.CommitterEmail,
+		},
+	}
+
+	// If no SHA specified, then create the file.
+	// Otherwise, update the file at the specified SHA.
+	if sha == "" {
+		opts.Branch = &gh.Branch
+		writeFunc = gh.client.Repositories.CreateFile
+	} else {
+		opts.SHA = github.String(sha)
+		writeFunc = gh.client.Repositories.UpdateFile
+	}
+
+	_, _, err = writeFunc(
+		context.Background(),
+		gh.RepositoryOwner,
+		gh.RepositoryName,
+		gh.fullPathName(filename),
+		opts,
+	)
+	return err
+}
+
+// deleteFile deletes a file from a Git tree and returns the new SHA for the ref
+// and any applicable errors. If an error occurs, the input SHA is returned along
+// with the error.
+func (gh GitHub) deleteFile(filename string, sha string) (string, error) {
+	commit, _, err := gh.client.Repositories.DeleteFile(
+		context.Background(),
+		gh.RepositoryOwner,
+		gh.RepositoryName,
+		gh.fullPathName(filename),
+		&github.RepositoryContentFileOptions{
+			Message: github.String(fmt.Sprintf("[checkup] delete %s [ci skip]", filename)),
+			SHA:     github.String(sha),
+			Committer: &github.CommitAuthor{
+				Name:  &gh.CommitterName,
+				Email: &gh.CommitterEmail,
+			},
+		},
+	)
+	if err != nil {
+		return sha, err
+	}
+
+	return *commit.Commit.SHA, nil
+}
+
+func (gh GitHub) readIndex() (map[string]int64, string, error) {
+	index := map[string]int64{}
+
+	contents, sha, err := gh.readFile(indexName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	err = json.Unmarshal(contents, &index)
+	return index, sha, err
+}
+
+func (gh GitHub) writeIndex(index map[string]int64, sha string) error {
+	contents, err := json.Marshal(index)
+	if err != nil {
+		return err
+	}
+
+	return gh.writeFile(indexName, sha, contents)
+}
+
+// Store stores results on filesystem according to the configuration in fs.
+func (gh GitHub) Store(results []Result) error {
+	// Write results to a new file
+	name := *GenerateFilename()
+	contents, err := json.Marshal(results)
+	if err != nil {
+		return err
+	}
+	err = gh.writeFile(name, "", contents)
+
+	// Read current index file
+	index, indexSHA, err := gh.readIndex()
+	if err != nil {
+		return err
+	}
+
+	// Add new file to index
+	index[name] = time.Now().UnixNano()
+
+	// Write new index
+	return gh.writeIndex(index, indexSHA)
+}
+
+// Maintain deletes check files that are older than fs.CheckExpiry.
+func (gh GitHub) Maintain() error {
+	if gh.CheckExpiry == 0 {
+		return nil
+	}
+
+	ref, _, err := gh.client.Git.GetRef(context.Background(), gh.RepositoryOwner, gh.RepositoryName, "heads/"+gh.Branch)
+	if err != nil {
+		return err
+	}
+	tree, _, err := gh.client.Git.GetTree(context.Background(), gh.RepositoryOwner, gh.RepositoryName, *ref.Object.SHA, true)
+	if err != nil {
+		return err
+	}
+	var files []string
+	for _, treeEntry := range tree.Entries {
+		files = append(files, *treeEntry.Path)
+	}
+
+	index, sha, err := gh.readIndex()
+	if err != nil {
+		return err
+	}
+
+	for _, fileName := range files {
+		if fileName == indexName {
+			continue
+		}
+		if gh.Dir != "" && !strings.HasPrefix(fileName, gh.Dir) {
+			continue
+		}
+
+		nsec, ok := index[fileName]
+		if !ok {
+			continue
+		}
+
+		if time.Since(time.Unix(0, nsec)) > gh.CheckExpiry {
+			sha, err = gh.deleteFile(fileName, sha)
+			if err != nil {
+				return err
+			}
+			delete(index, fileName)
+		}
+	}
+
+	return gh.writeIndex(index, sha)
+}

--- a/github.go
+++ b/github.go
@@ -119,7 +119,7 @@ func (gh *GitHub) writeFile(filename string, sha string, contents []byte) error 
 	var err error
 	var writeFunc func(context.Context, string, string, string, *github.RepositoryContentFileOptions) (*github.RepositoryContentResponse, *github.Response, error)
 	opts := &github.RepositoryContentFileOptions{
-		Message: github.String(fmt.Sprintf("[checkup] store %s [ci skip]", filename)),
+		Message: github.String(fmt.Sprintf("[checkup] store %s [ci skip]", gh.fullPathName(filename))),
 		Content: contents,
 		Committer: &github.CommitAuthor{
 			Name:  &gh.CommitterName,
@@ -170,7 +170,7 @@ func (gh *GitHub) deleteFile(filename string, sha string) (string, error) {
 		gh.RepositoryName,
 		gh.fullPathName(filename),
 		&github.RepositoryContentFileOptions{
-			Message: github.String(fmt.Sprintf("[checkup] delete %s [ci skip]", filepath.Base(filename))),
+			Message: github.String(fmt.Sprintf("[checkup] delete %s [ci skip]", gh.fullPathName(filename))),
 			SHA:     github.String(sha),
 			Committer: &github.CommitAuthor{
 				Name:  &gh.CommitterName,

--- a/github.go
+++ b/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"time"

--- a/github.go
+++ b/github.go
@@ -73,7 +73,7 @@ func (gh *GitHub) readFile(filename string) ([]byte, string, error) {
 		&github.RepositoryContentGetOptions{Ref: "heads/" + gh.Branch},
 	)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp.StatusCode == http.StatusNotFound {
 			return nil, "", errFileNotFound
 		}
 		return nil, "", err

--- a/github_test.go
+++ b/github_test.go
@@ -2,9 +2,11 @@ package checkup
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,6 +20,28 @@ import (
 )
 
 var checkFileRegexp = regexp.MustCompile(`\A\d+-check.json\z`)
+
+func mustWriteJSON(w io.Writer, data interface{}) {
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		panic(err)
+	}
+}
+
+func base64Encoded(input []byte) string {
+	return base64.StdEncoding.EncodeToString(input)
+}
+
+func toJSON(data interface{}) []byte {
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}
+
+func sha(data []byte) string {
+	return fmt.Sprintf("%x", sha1.Sum(data))
+}
 
 func TestGitHub(t *testing.T) {
 	results := []Result{{Title: "Testing"}}
@@ -50,107 +74,235 @@ func TestGitHub(t *testing.T) {
 		"1501523631505010894-check.json": time.Now().UnixNano(),
 		"1501525202306053005-check.json": time.Now().UnixNano(),
 	}
+	gitRepo := struct {
+		LastUpdated int64
+		Files       map[string]bool
+	}{
+		LastUpdated: time.Now().UnixNano(),
+		Files: map[string]bool{
+			"subdir/1501523631505010894-check.json": true,
+			"subdir/1501525202306053005-check.json": true,
+			"subdir/index.json":                     true,
+		},
+	}
 
-	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
+	serverSHAForRepo := sha(toJSON(gitRepo))
+
+	mux.HandleFunc("/repos/o/r/git/refs/heads/"+specimen.Branch, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Processing %s %s\n", r.Method, r.URL.Path)
 		if got := r.Method; got != "GET" {
 			t.Errorf("Request method: %v, want %v", got, "GET")
 		}
-		fmt.Fprint(w, `
-		  {
-		    "ref": "refs/heads/b",
-		    "url": "https://api.github.com/repos/o/r/git/refs/heads/b",
-		    "object": {
-		      "type": "commit",
-		      "sha": "aa218f56b14c9653891f9e74264a383fa43fefbd",
-		      "url": "https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"
-		    }
-		  }`)
+		mustWriteJSON(w, github.Reference{
+			Ref: github.String("refs/heads/" + specimen.Branch),
+			Object: &github.GitObject{
+				Type: github.String("commit"),
+				SHA:  github.String(serverSHAForRepo),
+			},
+		})
 	})
 
 	mux.HandleFunc("/repos/o/r/git/trees/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Processing %s %s\n", r.Method, r.URL.Path)
 		if got := r.FormValue("recursive"); got != "1" {
 			t.Errorf("Expected recursive flag to be 1, got %v", got)
 		}
-		desiredSHA := "aa218f56b14c9653891f9e74264a383fa43fefbd"
 
-		if sha := strings.TrimPrefix(r.URL.Path, "/repos/o/r/git/trees/"); sha != desiredSHA {
-			t.Errorf("Expected to fetch tree %s, got: %v", desiredSHA, sha)
+		if sha := strings.TrimPrefix(r.URL.Path, "/repos/o/r/git/trees/"); sha != serverSHAForRepo {
+			t.Errorf("Expected to fetch tree %s, got: %v", serverSHAForRepo, sha)
 		}
 
-		tree := struct {
-			SHA     string              `json:"sha,omitempty"`
-			Entries []map[string]string `json:"entries,omitempty"`
-		}{SHA: desiredSHA}
+		entries := []github.TreeEntry{
+			{
+				SHA:     github.String(sha(toJSON(index))),
+				Path:    github.String(filepath.Join(specimen.Dir, "index.json")),
+				Content: github.String(base64Encoded(toJSON(index))),
+			},
+		}
 		for filename, _ := range index {
-			tree.Entries = append(tree.Entries, map[string]string{
-				"sha":     desiredSHA,
-				"path":    filepath.Join(specimen.Dir, filename),
-				"content": string(resultsBytes),
+			entries = append(entries, github.TreeEntry{
+				SHA:     github.String(sha(resultsBytes)),
+				Path:    github.String(filepath.Join(specimen.Dir, filename)),
+				Content: github.String(string(resultsBytes)),
 			})
 		}
-		err := json.NewEncoder(w).Encode(tree)
-		if err != nil {
-			t.Errorf("Expected no error, got %+v", err)
-		}
+
+		mustWriteJSON(w, github.Tree{
+			SHA:     github.String(serverSHAForRepo),
+			Entries: entries,
+		})
 	})
 
 	mux.HandleFunc("/repos/o/r/contents/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Processing %s %s\n", r.Method, r.URL.Path)
 		path := strings.TrimPrefix(r.URL.Path, filepath.Join("/repos/o/r/contents/", specimen.Dir)+"/")
-		if got := r.Method; !(got == "GET" || got == "PUT") {
+		if got := r.Method; !(got == "GET" || got == "PUT" || got == "DELETE") {
 			t.Errorf("Request method: %v, want GET or PUT", got)
 		}
 		if got := r.FormValue("ref"); got != "" && got != "heads/b" {
 			t.Errorf("Expected heads/b, got %v", got)
 		}
 		if r.Method == "GET" && path == "index.json" {
-			encodedIndex, err := json.Marshal(index)
-			if err != nil {
-				t.Errorf("Expected no error, got %+v", err)
-			}
-			base64Index := base64.StdEncoding.EncodeToString(encodedIndex)
-			fmt.Fprintf(w, `
-                {
-                  "type": "file",
-                  "encoding": "base64",
-                  "name": "index.json",
-                  "path": "index.json",
-                  "content": "%s",
-                  "sha": "abcdef123456"
-                }`, base64Index)
+			mustWriteJSON(w, github.RepositoryContent{
+				Type:     github.String("file"),
+				Encoding: github.String("base64"),
+				Size:     github.Int(len(base64Encoded(toJSON(index)))),
+				Name:     github.String("index.json"),
+				Path:     github.String(filepath.Join(specimen.Dir, "index.json")),
+				Content:  github.String(base64Encoded(toJSON(index))),
+				SHA:      github.String(serverSHAForRepo),
+			})
 			return
 		}
 		if r.Method == "PUT" && path == "index.json" {
 			// 1. Enforce body contains message, committer, content (base64-encoded), sha
+			stuff := struct {
+				Message   string            `json:"message"`
+				Content   string            `json:"content"`
+				SHA       string            `json:"sha"`
+				Committer map[string]string `json:"committer"`
+			}{}
+			if err := json.NewDecoder(r.Body).Decode(&stuff); err != nil {
+				t.Errorf("Expected body to decode fine, but got %+v", err)
+			}
+			if stuff.Message != "[checkup] store index.json [ci skip]" {
+				t.Errorf("Expected a certain commit message, got '%s'", stuff.Message)
+			}
+			if stuff.SHA != serverSHAForRepo {
+				t.Errorf("Expected SHA to be %s, got '%s'", serverSHAForRepo, stuff.SHA)
+			}
+			if stuff.Committer["email"] != specimen.CommitterEmail {
+				t.Errorf("Expected email to be %s, got %s", specimen.CommitterEmail, stuff.Committer["email"])
+			}
+			if stuff.Committer["name"] != specimen.CommitterName {
+				t.Errorf("Expected name to be %s, got %s", specimen.CommitterName, stuff.Committer["name"])
+			}
 			// 2. Return object based on https://developer.github.com/v3/repos/contents/#update-a-file
+			gitRepo.LastUpdated = time.Now().UnixNano()
+			serverSHAForRepo = sha(toJSON(gitRepo))
+			mustWriteJSON(w, github.RepositoryContentResponse{
+				Content: &github.RepositoryContent{
+					Type:     github.String("file"),
+					Encoding: github.String("base64"),
+					Size:     github.Int(len(base64Encoded(toJSON(index)))),
+					Name:     github.String("index.json"),
+					Path:     github.String(filepath.Join(specimen.Dir, "index.json")),
+					Content:  github.String(base64Encoded(toJSON(index))),
+					SHA:      github.String(sha(toJSON(index))),
+				},
+				Commit: github.Commit{
+					SHA: github.String(serverSHAForRepo),
+				},
+			})
 			return
 		}
 		if r.Method == "GET" && checkFileRegexp.MatchString(path) {
 			_, ok := index[path]
 			if ok {
-				base64Index := base64.StdEncoding.EncodeToString(resultsBytes)
-				fmt.Fprintf(w, `
-                    {
-                      "type": "file",
-                      "encoding": "base64",
-                      "content": "%s",
-                      "sha": "abcdef123456"
-                    }`, base64Index)
+				mustWriteJSON(w, github.RepositoryContent{
+					Type:     github.String("file"),
+					Encoding: github.String("base64"),
+					Size:     github.Int(len(base64Encoded(resultsBytes))),
+					Name:     github.String(path),
+					Path:     github.String(filepath.Join(specimen.Dir, path)),
+					Content:  github.String(base64Encoded(resultsBytes)),
+					SHA:      github.String(sha(resultsBytes)),
+				})
 			} else {
-				http.Error(w, path+" does not exist", 403)
+				http.Error(w, path+" does not exist", 404)
 			}
 			return
 		}
 		if r.Method == "PUT" && checkFileRegexp.MatchString(path) {
-			shortPath := strings.TrimPrefix(path, "subdir/")
-			_, ok := index[shortPath]
-			index[shortPath] = time.Now().UnixNano()
-			if ok {
-				// You're updating the file!
-				// 2. Return object based on https://developer.github.com/v3/repos/contents/#update-a-file
-			} else {
-				// You're creating the file!
-				// 2. Return object based on https://developer.github.com/v3/repos/contents/#create-a-file
+			index[path] = time.Now().UnixNano()
+
+			gitRepo.Files[filepath.Join(specimen.Dir, path)] = true
+			gitRepo.LastUpdated = time.Now().UnixNano()
+			serverSHAForRepo = sha(toJSON(gitRepo))
+
+			// 1. Enforce body contains message, committer, content (base64-encoded), sha
+			stuff := struct {
+				Message   string            `json:"message"`
+				Content   string            `json:"content"`
+				SHA       string            `json:"sha"`
+				Committer map[string]string `json:"committer"`
+			}{}
+			if err := json.NewDecoder(r.Body).Decode(&stuff); err != nil {
+				t.Errorf("Expected body to decode fine, but got %+v", err)
 			}
+			if stuff.Message != fmt.Sprintf("[checkup] store %s [ci skip]", path) {
+				t.Errorf("Expected a certain commit message, got '%s'", stuff.Message)
+			}
+			if stuff.SHA != "" {
+				t.Errorf("Expected SHA to be empty, got '%s'", stuff.SHA)
+			}
+			if stuff.Committer["email"] != specimen.CommitterEmail {
+				t.Errorf("Expected email to be %s, got %s", specimen.CommitterEmail, stuff.Committer["email"])
+			}
+			if stuff.Committer["name"] != specimen.CommitterName {
+				t.Errorf("Expected name to be %s, got %s", specimen.CommitterName, stuff.Committer["name"])
+			}
+
+			// Response is the same if updating or creating.
+			mustWriteJSON(w, github.RepositoryContentResponse{
+				Content: &github.RepositoryContent{
+					Type:     github.String("file"),
+					Encoding: github.String("base64"),
+					Size:     github.Int(len(base64Encoded(resultsBytes))),
+					Name:     github.String(path),
+					Path:     github.String(filepath.Join(specimen.Dir, path)),
+					Content:  github.String(base64Encoded(resultsBytes)),
+					SHA:      github.String(sha(resultsBytes)),
+				},
+				Commit: github.Commit{
+					SHA: github.String(serverSHAForRepo),
+				},
+			})
+			return
+		}
+		if r.Method == "DELETE" && checkFileRegexp.MatchString(path) {
+			// 1. Enforce body contains message, committer, content (base64-encoded), sha
+			stuff := struct {
+				Message   string            `json:"message"`
+				Content   string            `json:"content"`
+				SHA       string            `json:"sha"`
+				Committer map[string]string `json:"committer"`
+			}{}
+			if err := json.NewDecoder(r.Body).Decode(&stuff); err != nil {
+				t.Errorf("Expected body to decode fine, but got %+v", err)
+			}
+			if expected := fmt.Sprintf("[checkup] delete %s [ci skip]", path); stuff.Message != expected {
+				t.Errorf("Expected commit message to be '%s', got '%s'", expected, stuff.Message)
+			}
+			if stuff.SHA != serverSHAForRepo {
+				t.Errorf("Expected SHA to be %s, got '%s'", serverSHAForRepo, stuff.SHA)
+			}
+			if stuff.Committer["email"] != specimen.CommitterEmail {
+				t.Errorf("Expected email to be %s, got %s", specimen.CommitterEmail, stuff.Committer["email"])
+			}
+			if stuff.Committer["name"] != specimen.CommitterName {
+				t.Errorf("Expected name to be %s, got %s", specimen.CommitterName, stuff.Committer["name"])
+			}
+
+			// Ok, start modifying the in-memory state.
+			if _, ok := index[path]; !ok {
+				http.Error(w, "no such file: "+path, 500)
+			}
+			delete(index, path)
+
+			if _, ok := gitRepo.Files[filepath.Join(specimen.Dir, path)]; !ok {
+				http.Error(w, "file was deleted", 401)
+			}
+			gitRepo.Files[filepath.Join(specimen.Dir, path)] = false
+			gitRepo.LastUpdated = time.Now().UnixNano()
+			serverSHAForRepo = sha(toJSON(gitRepo))
+
+			// Response is the same if updating or creating.
+			mustWriteJSON(w, github.RepositoryContentResponse{
+				Commit: github.Commit{
+					SHA: github.String(serverSHAForRepo),
+				},
+			})
 			return
 		}
 		http.Error(w, path+" is not handled", 403)
@@ -162,6 +314,8 @@ func TestGitHub(t *testing.T) {
 	if err := specimen.Store(results); err != nil {
 		t.Fatalf("Expected no error from Store(), got: %v", err)
 	}
+
+	fmt.Println("Done with Store()")
 
 	// Make sure index has been created
 	index, _, err := specimen.readIndex()
@@ -188,6 +342,7 @@ func TestGitHub(t *testing.T) {
 
 	// Make sure check file bytes are correct
 	checkfile := filepath.Join(specimen.Dir, name)
+	fmt.Printf("checking %s\n", checkfile)
 	b, _, err := specimen.readFile(checkfile)
 	if err != nil {
 		t.Fatalf("Expected no error reading body, got: %v", err)
@@ -209,7 +364,7 @@ func TestGitHub(t *testing.T) {
 	if err := specimen.Maintain(); err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
-	if _, _, err := specimen.readFile(checkfile); err != nil {
+	if _, _, err := specimen.readFile(checkfile); err != nil && err != errFileNotFound {
 		t.Fatalf("Expected checkfile to be deleted, but Stat() returned error: %v", err)
 	}
 }

--- a/github_test.go
+++ b/github_test.go
@@ -1,0 +1,215 @@
+package checkup
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/github"
+)
+
+var checkFileRegexp = regexp.MustCompile(`\A\d+-check.json\z`)
+
+func TestGitHub(t *testing.T) {
+	results := []Result{{Title: "Testing"}}
+	resultsBytes := []byte(`[{"title":"Testing"}]` + "\n")
+
+	// test server
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	// github client configured to use test server
+	client := github.NewClient(nil)
+	url, _ := url.Parse(server.URL)
+	client.BaseURL = url
+	client.UploadURL = url
+	defer server.Close()
+
+	// Our subject, our specimen.
+	specimen := GitHub{
+		RepositoryOwner: "o",
+		RepositoryName:  "r",
+		CommitterName:   "John Appleseed",
+		CommitterEmail:  "appleseed@example.org",
+		Branch:          "b",
+		Dir:             "subdir/",
+		client:          client,
+	}
+
+	// files := map[string]string{}
+	index := map[string]int64{
+		"1501523631505010894-check.json": time.Now().UnixNano(),
+		"1501525202306053005-check.json": time.Now().UnixNano(),
+	}
+
+	mux.HandleFunc("/repos/o/r/git/refs/heads/b", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Method; got != "GET" {
+			t.Errorf("Request method: %v, want %v", got, "GET")
+		}
+		fmt.Fprint(w, `
+		  {
+		    "ref": "refs/heads/b",
+		    "url": "https://api.github.com/repos/o/r/git/refs/heads/b",
+		    "object": {
+		      "type": "commit",
+		      "sha": "aa218f56b14c9653891f9e74264a383fa43fefbd",
+		      "url": "https://api.github.com/repos/o/r/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"
+		    }
+		  }`)
+	})
+
+	mux.HandleFunc("/repos/o/r/git/trees/", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.FormValue("recursive"); got != "1" {
+			t.Errorf("Expected recursive flag to be 1, got %v", got)
+		}
+		desiredSHA := "aa218f56b14c9653891f9e74264a383fa43fefbd"
+
+		if sha := strings.TrimPrefix(r.URL.Path, "/repos/o/r/git/trees/"); sha != desiredSHA {
+			t.Errorf("Expected to fetch tree %s, got: %v", desiredSHA, sha)
+		}
+
+		tree := struct {
+			SHA     string              `json:"sha,omitempty"`
+			Entries []map[string]string `json:"entries,omitempty"`
+		}{SHA: desiredSHA}
+		for filename, _ := range index {
+			tree.Entries = append(tree.Entries, map[string]string{
+				"sha":     desiredSHA,
+				"path":    filepath.Join(specimen.Dir, filename),
+				"content": string(resultsBytes),
+			})
+		}
+		err := json.NewEncoder(w).Encode(tree)
+		if err != nil {
+			t.Errorf("Expected no error, got %+v", err)
+		}
+	})
+
+	mux.HandleFunc("/repos/o/r/contents/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, filepath.Join("/repos/o/r/contents/", specimen.Dir)+"/")
+		if got := r.Method; !(got == "GET" || got == "PUT") {
+			t.Errorf("Request method: %v, want GET or PUT", got)
+		}
+		if got := r.FormValue("ref"); got != "" && got != "heads/b" {
+			t.Errorf("Expected heads/b, got %v", got)
+		}
+		if r.Method == "GET" && path == "index.json" {
+			encodedIndex, err := json.Marshal(index)
+			if err != nil {
+				t.Errorf("Expected no error, got %+v", err)
+			}
+			base64Index := base64.StdEncoding.EncodeToString(encodedIndex)
+			fmt.Fprintf(w, `
+                {
+                  "type": "file",
+                  "encoding": "base64",
+                  "name": "index.json",
+                  "path": "index.json",
+                  "content": "%s",
+                  "sha": "abcdef123456"
+                }`, base64Index)
+			return
+		}
+		if r.Method == "PUT" && path == "index.json" {
+			// 1. Enforce body contains message, committer, content (base64-encoded), sha
+			// 2. Return object based on https://developer.github.com/v3/repos/contents/#update-a-file
+			return
+		}
+		if r.Method == "GET" && checkFileRegexp.MatchString(path) {
+			_, ok := index[path]
+			if ok {
+				base64Index := base64.StdEncoding.EncodeToString(resultsBytes)
+				fmt.Fprintf(w, `
+                    {
+                      "type": "file",
+                      "encoding": "base64",
+                      "content": "%s",
+                      "sha": "abcdef123456"
+                    }`, base64Index)
+			} else {
+				http.Error(w, path+" does not exist", 403)
+			}
+			return
+		}
+		if r.Method == "PUT" && checkFileRegexp.MatchString(path) {
+			shortPath := strings.TrimPrefix(path, "subdir/")
+			_, ok := index[shortPath]
+			index[shortPath] = time.Now().UnixNano()
+			if ok {
+				// You're updating the file!
+				// 2. Return object based on https://developer.github.com/v3/repos/contents/#update-a-file
+			} else {
+				// You're creating the file!
+				// 2. Return object based on https://developer.github.com/v3/repos/contents/#create-a-file
+			}
+			return
+		}
+		http.Error(w, path+" is not handled", 403)
+		t.Errorf("Cannot handle %s %s (path=%s)", r.Method, r.URL.Path, path)
+	})
+
+	// Here goes!
+
+	if err := specimen.Store(results); err != nil {
+		t.Fatalf("Expected no error from Store(), got: %v", err)
+	}
+
+	// Make sure index has been created
+	index, _, err := specimen.readIndex()
+	if err != nil {
+		t.Fatalf("Cannot read index: %v", err)
+	}
+
+	if len(index) != 3 {
+		t.Fatalf("Expected length of index to be 3, but got %v", len(index))
+	}
+
+	var (
+		name string
+		nsec int64
+	)
+	for name, nsec = range index {
+	}
+
+	// Make sure index has timestamp of check
+	ts := time.Unix(0, nsec)
+	if time.Since(ts) > 1*time.Second {
+		t.Errorf("Timestamp of check is %s but expected something very recent", ts)
+	}
+
+	// Make sure check file bytes are correct
+	checkfile := filepath.Join(specimen.Dir, name)
+	b, _, err := specimen.readFile(checkfile)
+	if err != nil {
+		t.Fatalf("Expected no error reading body, got: %v", err)
+	}
+	if bytes.Compare(b, resultsBytes) != 0 {
+		t.Errorf("Contents of file are wrong\nExpected %s\nGot %s", resultsBytes, b)
+	}
+
+	// Make sure check file is not deleted after maintain with CheckExpiry == 0
+	if err := specimen.Maintain(); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if _, _, err := specimen.readFile(checkfile); err != nil {
+		t.Fatalf("Expected not error calling Stat() on checkfile, got: %v", err)
+	}
+
+	// Make sure checkfile is deleted after maintain with CheckExpiry > 0
+	specimen.CheckExpiry = 1 * time.Nanosecond
+	if err := specimen.Maintain(); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if _, _, err := specimen.readFile(checkfile); err != nil {
+		t.Fatalf("Expected checkfile to be deleted, but Stat() returned error: %v", err)
+	}
+}

--- a/github_test.go
+++ b/github_test.go
@@ -98,7 +98,6 @@ func withGitHubServer(t *testing.T, specimen GitHub, f func(*github.Client)) {
 	serverSHAForRepo := sha(toJSON(gitRepo))
 
 	mux.HandleFunc("/repos/o/r/git/refs/heads/"+specimen.Branch, func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("Processing %s %s\n", r.Method, r.URL.Path)
 		if got := r.Method; got != "GET" {
 			t.Errorf("Request method: %v, want %v", got, "GET")
 		}
@@ -112,7 +111,6 @@ func withGitHubServer(t *testing.T, specimen GitHub, f func(*github.Client)) {
 	})
 
 	mux.HandleFunc("/repos/o/r/git/trees/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("Processing %s %s\n", r.Method, r.URL.Path)
 		if got := r.FormValue("recursive"); got != "1" {
 			t.Errorf("Expected recursive flag to be 1, got %v", got)
 		}
@@ -143,7 +141,6 @@ func withGitHubServer(t *testing.T, specimen GitHub, f func(*github.Client)) {
 	})
 
 	mux.HandleFunc("/repos/o/r/contents/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("Processing %s %s\n", r.Method, r.URL.Path)
 		path := strings.TrimPrefix(r.URL.Path, "/repos/o/r/contents")
 		if got := r.Method; !(got == "GET" || got == "PUT" || got == "DELETE") {
 			t.Errorf("Request method: %v, want GET or PUT", got)
@@ -266,7 +263,6 @@ func withGitHubServer(t *testing.T, specimen GitHub, f func(*github.Client)) {
 			delete(index, filepath.Base(path))
 
 			if _, ok := gitRepo.Files[pathForGitRepo(path)]; !ok {
-				fmt.Printf("path=%s index=%+v repo: %+v\n", path, index, gitRepo.Files)
 				http.Error(w, "file was deleted", 401)
 				return
 			}
@@ -307,8 +303,6 @@ func TestGitHubWithoutSubdir(t *testing.T) {
 			t.Fatalf("Expected no error from Store(), got: %v", err)
 		}
 
-		fmt.Println("Done with Store()")
-
 		// Make sure index has been created
 		index, _, err := specimen.readIndex()
 		if err != nil {
@@ -334,7 +328,6 @@ func TestGitHubWithoutSubdir(t *testing.T) {
 		}
 
 		// Make sure check file bytes are correct
-		fmt.Printf("checking %s\n", name)
 		b, _, err := specimen.readFile(name)
 		if err != nil {
 			t.Fatalf("Expected no error reading body, got: %v", err)
@@ -380,8 +373,6 @@ func TestGitHubWithSubdir(t *testing.T) {
 			t.Fatalf("Expected no error from Store(), got: %v", err)
 		}
 
-		fmt.Println("Done with Store()")
-
 		// Make sure index has been created
 		index, _, err := specimen.readIndex()
 		if err != nil {
@@ -408,7 +399,6 @@ func TestGitHubWithSubdir(t *testing.T) {
 
 		// Make sure check file bytes are correct
 		checkfile := filepath.Join(specimen.Dir, name)
-		fmt.Printf("checking %s\n", checkfile)
 		b, _, err := specimen.readFile(checkfile)
 		if err != nil {
 			t.Fatalf("Expected no error reading body, got: %v", err)

--- a/github_test.go
+++ b/github_test.go
@@ -249,8 +249,8 @@ func withGitHubServer(t *testing.T, specimen GitHub, f func(*github.Client)) {
 			if expected := fmt.Sprintf("[checkup] delete %s [ci skip]", strings.TrimPrefix(path, "/")); stuff.Message != expected {
 				t.Errorf("Expected commit message to be '%s', got '%s'", expected, stuff.Message)
 			}
-			if stuff.SHA != serverSHAForRepo {
-				t.Errorf("Expected SHA to be %s, got '%s'", serverSHAForRepo, stuff.SHA)
+			if stuff.SHA != sha(resultsBytes) {
+				t.Errorf("Expected SHA to be %s, got '%s'", sha(resultsBytes), stuff.SHA)
 			}
 			if stuff.Committer["email"] != specimen.CommitterEmail {
 				t.Errorf("Expected email to be %s, got %s", specimen.CommitterEmail, stuff.Committer["email"])
@@ -272,7 +272,7 @@ func withGitHubServer(t *testing.T, specimen GitHub, f func(*github.Client)) {
 			}
 			gitRepo.Files[pathForGitRepo(path)] = false
 			gitRepo.LastUpdated = time.Now().UnixNano()
-			serverSHAForRepo = sha(toJSON(gitRepo))
+			// Don't update the server SHA.
 
 			// Response is the same if updating or creating.
 			mustWriteJSON(w, github.RepositoryContentResponse{


### PR DESCRIPTION
Closes #53.

[See it in action.](https://www.parkermoore.de/status/) ([repo](https://github.com/parkr/status)).

This is *very* rough and undocumented code. It makes a number of GitHub REST API requests to push JSON files; it's modeled off the `FS` provider. The testing code is similarly modeled after the `FS` provider's texts. I basically implement the 4 endpoints I use in a test server and keep a "git repo" and index in memory. 😆 

I expect this code to evolve & drastically improve with your input.

Configuration is as follows (all fields presently required):

```json
{
  "storage": {
    "provider": "github",
    "access_token": "some_api_access_token_with_repo_scope",
    "repository_owner": "owner",
    "repository_name": "repo",
    "committer_name": "User Name",
    "committer_email": "username@example.com",
    "branch": "gh-pages",
    "dir": "updates"
  }
}
```

The `"dir"` field is like the `FS` storage layer: it pushes all `.json` files to a specific subdirectory in your Git.

Setup:

1. Create a repository.
2. Copy the contents of `statuspage` from this repo to the root of your new repo.
3. Change `index.html` to pull in `js/fs.js` instead of `js/s3.js`.
4. Create `updates/.gitkeep`. This code currently does not create the `updates/` directory.
5. Enable GitHub Pages in your settings for your desired branch.
6. Run `checkup --store`.

Please let me know if this is something you'd find useful.