### PR TITLE
Logging: provide command-line control

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,5 +98,5 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "checkup.json", "JSON config file")
 	RootCmd.Flags().BoolVar(&storeResults, "store", false, "Store results")
-	RootCmd.Flags().BoolVar(&printLogs, "v", false, "Print logging")
+	RootCmd.Flags().BoolVar(&printLogs, "v", false, "Enable logging to standard output")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 
 var configFile string
 var storeResults bool
+var printLogs bool
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -31,6 +32,10 @@ a single checkup and print results to stdout. To
 store the results of the check, use --store.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		if printLogs {
+			log.SetOutput(os.Stdout)
+		}
+
 		allHealthy := true
 		c := loadCheckup()
 
@@ -93,4 +98,5 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "checkup.json", "JSON config file")
 	RootCmd.Flags().BoolVar(&storeResults, "store", false, "Store results")
+	RootCmd.Flags().BoolVar(&printLogs, "v", false, "Print logging")
 }

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,10 @@
+package checkup
+
+import (
+	"io/ioutil"
+	"log"
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}


### PR DESCRIPTION
In https://github.com/sourcegraph/checkup/pull/54, @mholt mentioned that allowing the possibility of logging would be nice. I agree.

This PR turns logging off by default (by sending logs to `ioutil.Discard`), with the ability to enable it via the `-v` flag.