### PR TITLE
Add DisableColor() to disable colors in string formating

### DIFF
--- a/checkup.go
+++ b/checkup.go
@@ -500,6 +500,11 @@ func (r Result) Status() StatusText {
 	return Unknown
 }
 
+// DisableColor disables ANSI colors in the Result default string.
+func DisableColor() {
+	color.NoColor = true
+}
+
 // StatusText is the textual representation of the
 // result of a status check.
 type StatusText string


### PR DESCRIPTION
checkup adds ANSI escape sequences to have a user-friendly output on the command line.

However, this is not helpful when used as a library.

The patch included in this PR adds a DisableColor helper function that can be called in order to disable the terminal colors sequences.