### PR TITLE
Extend Storage interface

### DIFF
--- a/checkup.go
+++ b/checkup.go
@@ -359,6 +359,12 @@ type Storage interface {
 	Store([]Result) error
 }
 
+// StorageReader can read results from the Storage.
+type StorageReader interface {
+	Fetch(string) ([]Result, error)
+	GetIndex() (map[string]int64, error)
+}
+
 // Maintainer can maintain a store of results by
 // deleting old check files that are no longer
 // needed or performing other required tasks.

--- a/fs.go
+++ b/fs.go
@@ -24,6 +24,11 @@ type FS struct {
 	CheckExpiry time.Duration `json:"check_expiry,omitempty"`
 }
 
+// GetIndex returns the index from filesystem.
+func (fs FS) GetIndex() (map[string]int64, error) {
+	return fs.readIndex()
+}
+
 func (fs FS) readIndex() (map[string]int64, error) {
 	index := map[string]int64{}
 
@@ -47,6 +52,22 @@ func (fs FS) writeIndex(index map[string]int64) error {
 	defer f.Close()
 
 	return json.NewEncoder(f).Encode(index)
+}
+
+// Fetch fetches results from filesystem for the specified index.
+func (fs FS) Fetch(name string) ([]Result, error) {
+	f, err := os.Open(filepath.Join(fs.Dir, name))
+	if err != nil {
+		return nil, err
+	}
+	var results []Result
+	err = json.NewDecoder(f).Decode(&results)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }
 
 // Store stores results on filesystem according to the configuration in fs.

--- a/fs_test.go
+++ b/fs_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestFS(t *testing.T) {
 	results := []Result{{Title: "Testing"}}
-	resultsBytes := []byte(`[{"title":"Testing"}]`+"\n")
+	resultsBytes := []byte(`[{"title":"Testing"}]` + "\n")
 
 	dir, err := ioutil.TempDir("", "checkup")
 	if err != nil {
@@ -41,7 +41,8 @@ func TestFS(t *testing.T) {
 		name string
 		nsec int64
 	)
-	for name, nsec = range index {}
+	for name, nsec = range index {
+	}
 
 	// Make sure index has timestamp of check
 	ts := time.Unix(0, nsec)
@@ -57,6 +58,33 @@ func TestFS(t *testing.T) {
 	}
 	if bytes.Compare(b, resultsBytes) != 0 {
 		t.Errorf("Contents of file are wrong\nExpected %s\nGot %s", resultsBytes, b)
+	}
+
+	// Test the StorageReader interface
+	index, err = specimen.GetIndex()
+	if err != nil {
+		t.Fatalf("StoreReader: cannot read index: %v", err)
+	}
+
+	if len(index) != 1 {
+		t.Fatalf("StoreReader: expected length of index to be 1, but got %v", len(index))
+	}
+
+	var indexKey string
+	for k := range index {
+		indexKey = k // Get first (and unique) key
+		break
+	}
+	testResults, err := specimen.Fetch(indexKey)
+	if err != nil {
+		t.Fatalf("StoreReader: cannot fetch contents for '%s': %v", indexKey, err)
+	}
+	if len(testResults) != 1 {
+		t.Fatalf("StoreReader: expected length of []Result to be 1, but got %v", len(testResults))
+	}
+
+	if testResults[0].Title != results[0].Title {
+		t.Fatalf("StoreReader: expected test result title to be '%s', but got '%s'", results[0].Title, testResults[0].Title)
 	}
 
 	// Make sure check file is not deleted after maintain with CheckExpiry == 0

--- a/github.go
+++ b/github.go
@@ -241,6 +241,23 @@ func (gh *GitHub) Store(results []Result) error {
 	return gh.writeIndex(index, indexSHA)
 }
 
+// Fetch returns a checkup record -- Not tested!
+func (gh *GitHub) Fetch(name string) ([]Result, error) {
+	contents, _, err := gh.readFile(name)
+	if err != nil {
+		return nil, err
+	}
+	var r []Result
+	err = json.Unmarshal(contents, &r)
+	return r, err
+}
+
+// GetIndex returns the checkup index
+func (gh *GitHub) GetIndex() (map[string]int64, error) {
+	m, _, e := gh.readIndex()
+	return m, e
+}
+
 // Maintain deletes check files that are older than gh.CheckExpiry.
 func (gh *GitHub) Maintain() error {
 	if gh.CheckExpiry == 0 {


### PR DESCRIPTION
Add Fetch and GetIndex to the Storage interface.

This enables the library to be used not only to save records
but also to read them back.

The FS backend is implemented, the Github backend is updated but not
tested, and the S3 has dummy handlers that currently return a "not-implemented"
error.

The idea is to be able to use checkup to read existing data instead of duplicating the code.