### PR TITLE
SQL storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Checkup implements these storage providers:
 - Amazon S3
 - Local file system
 - GitHub
+- SQL (sqlite3)
 
 Checkup can even send notifications through your service of choice (if an integration exists).
 
@@ -202,6 +203,26 @@ Where "dir" is a subdirectory within the repo to push all the check files. Setup
 4. Create `updates/.gitkeep`.
 5. Enable GitHub Pages in your settings for your desired branch.
 
+#### SQL(ite) Storage
+
+**[godoc: SQL](https://godoc.org/github.com/sourcegraph/checkup#SQL)**
+
+A sqlite3 database file can be used as storage backend.
+
+```json
+{
+	"provider": "sql",
+	"sqlite_db_file": "/path/to/your/sqlite.db"
+}
+```
+
+The database must exist and a "checks" table should be created:
+
+```
+CREATE TABLE checks (name TEXT NOT NULL PRIMARY KEY, timestamp INT8, results TEXT);
+```
+
+Currently the status page does not support SQL storage.
 
 
 ## Setting up storage on S3

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ sqlite database file configuration:
 }
 ```
 
-The SQL engine used depends on which one is configured; if both sqlite and Postgres configurations are present, sqlite is used.
+The SQL engine used depends on which one is configured.
 
 For all database backends, the database must exist and a "checks" table should be created:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Checkup implements these storage providers:
 - Amazon S3
 - Local file system
 - GitHub
-- SQL (sqlite3)
+- SQL (sqlite3 or PostgreSQL)
 
 Checkup can even send notifications through your service of choice (if an integration exists).
 
@@ -203,12 +203,13 @@ Where "dir" is a subdirectory within the repo to push all the check files. Setup
 4. Create `updates/.gitkeep`.
 5. Enable GitHub Pages in your settings for your desired branch.
 
-#### SQL(ite) Storage
+#### SQL Storage (sqlite3/PostgreSQL)
 
 **[godoc: SQL](https://godoc.org/github.com/sourcegraph/checkup#SQL)**
 
-A sqlite3 database file can be used as storage backend.
+Postgres or sqlite3 databases can be used as storage backends.
 
+sqlite database file configuration:
 ```json
 {
 	"provider": "sql",
@@ -216,7 +217,24 @@ A sqlite3 database file can be used as storage backend.
 }
 ```
 
-The database must exist and a "checks" table should be created:
+sqlite database file configuration:
+```json
+{
+	"provider": "sql",
+	"postgresql": {
+		"user": "postgres",
+		"dbname": "dbname",
+		"host": "localhost",
+		"port": 5432,
+		"password": "password",
+		"sslmode": "disable"
+	}
+}
+```
+
+The SQL engine used depends on which one is configured; if both sqlite and Postgres configurations are present, sqlite is used.
+
+For all database backends, the database must exist and a "checks" table should be created:
 
 ```
 CREATE TABLE checks (name TEXT NOT NULL PRIMARY KEY, timestamp INT8, results TEXT);

--- a/checkup.go
+++ b/checkup.go
@@ -210,8 +210,10 @@ func (c Checkup) MarshalJSON() ([]byte, error) {
 			providerName = "s3"
 		case FS:
 			providerName = "fs"
+		case SQL:
+			providerName = "sql"
 		default:
-			return result, fmt.Errorf("unknown Storage type")
+			return result, fmt.Errorf("unknown Storage type: %T", c.Storage)
 		}
 		sb = []byte(fmt.Sprintf(`{"provider":"%s",%s`, providerName, string(sb[1:])))
 		wrap("storage", sb)
@@ -331,6 +333,13 @@ func (c *Checkup) UnmarshalJSON(b []byte) error {
 		case "github":
 			storage := &GitHub{}
 			err = json.Unmarshal(raw.Storage, storage)
+			if err != nil {
+				return err
+			}
+			c.Storage = storage
+		case "sql":
+			var storage SQL
+			err = json.Unmarshal(raw.Storage, &storage)
 			if err != nil {
 				return err
 			}

--- a/sql.go
+++ b/sql.go
@@ -1,0 +1,137 @@
+package checkup
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3" // Enable sqlite3 backend
+)
+
+// schema is the table schema expected by the sqlite3 checkup storage.
+const schema = `
+CREATE TABLE checks (
+    name TEXT NOT NULL PRIMARY KEY,
+    timestamp INT8 NOT NULL,
+    results TEXT
+);
+CREATE UNIQUE INDEX idx_checks_timestamp ON checks(timestamp);
+`
+
+// SQL is a way to store checkup results in a SQL database.
+type SQL struct {
+	// The sqlite3 DB where check results will be stored.
+	SqliteDBFile string `json:"sqlite_db_file"`
+
+	// Check files older than CheckExpiry will be
+	// deleted on calls to Maintain(). If this is
+	// the zero value, no old check files will be
+	// deleted.
+	CheckExpiry time.Duration `json:"check_expiry,omitempty"`
+}
+
+func (sql SQL) dbConnect() (*sqlx.DB, error) {
+	// TODO: support other databases
+	return sqlx.Connect("sqlite3", sql.SqliteDBFile)
+}
+
+// GetIndex returns the list of check results for the database.
+func (sql SQL) GetIndex() (map[string]int64, error) {
+	db, err := sql.dbConnect()
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	idx := make(map[string]int64)
+	var check struct {
+		Name      string `db:"name"`
+		Timestamp int64  `db:"timestamp"`
+	}
+
+	rows, err := db.Queryx(`SELECT name,timestamp FROM "checks"`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		err := rows.StructScan(&check)
+		if err != nil {
+			rows.Close()
+			return nil, err
+		}
+		idx[check.Name] = check.Timestamp
+	}
+
+	return idx, nil
+}
+
+// Fetch fetches results of the check with given name.
+func (sql SQL) Fetch(name string) ([]Result, error) {
+	db, err := sql.dbConnect()
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	var checkResult []byte
+	var results []Result
+
+	err = db.Get(&checkResult, `SELECT results FROM "checks" WHERE name=? LIMIT 1`, name)
+	if err != nil {
+		return nil, err
+	}
+	if err = json.Unmarshal(checkResult, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// Store stores results in the database.
+func (sql SQL) Store(results []Result) error {
+	db, err := sql.dbConnect()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	name := *GenerateFilename()
+	contents, err := json.Marshal(results)
+	if err != nil {
+		return err
+	}
+
+	// Insert data
+	const insertResults = `INSERT INTO "checks" (name, timestamp, results) VALUES (?, ?, ?)`
+	_, err = db.Exec(insertResults, name, time.Now().UnixNano(), contents)
+	return err
+}
+
+// Maintain deletes check files that are older than sql.CheckExpiry.
+func (sql SQL) Maintain() error {
+	if sql.CheckExpiry == 0 {
+		return nil
+	}
+
+	db, err := sql.dbConnect()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	const st = `DELETE FROM "checks" WHERE timestamp < ?`
+	ts := time.Now().Add(-1 * sql.CheckExpiry).UnixNano()
+	_, err = db.Exec(st, ts)
+	return err
+}
+
+// initialize creates the "checks" table in the database.
+func (sql SQL) initialize() error {
+	db, err := sql.dbConnect()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	_, err = db.Exec(schema)
+	return err
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,0 +1,96 @@
+package checkup
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSQL(t *testing.T) {
+	results := []Result{{Title: "Testing"}}
+
+	// Create temporary directory for the tests
+	dir, err := ioutil.TempDir("", "checkup")
+	if err != nil {
+		t.Fatalf("Cannot create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	dbFile := filepath.Join(dir, "checkuptest.db")
+
+	specimen := SQL{
+		SqliteDBFile: dbFile,
+	}
+
+	if err := specimen.initialize(); err != nil {
+		t.Fatalf("Could not initialize test database, got: %v", err)
+	}
+
+	if err := specimen.Store(results); err != nil {
+		t.Fatalf("Expected no error from Store(), got: %v", err)
+	}
+
+	// Test GetIndex (StorageReader interface)
+	index, err := specimen.GetIndex()
+	if err != nil {
+		t.Fatalf("StoreReader: cannot read index: %v", err)
+	}
+
+	if len(index) != 1 {
+		t.Fatalf("Expected length of index to be 1, but got %v", len(index))
+	}
+
+	var (
+		name string
+		nsec int64
+	)
+	for name, nsec = range index {
+	}
+
+	// Make sure index has timestamp of check
+	ts := time.Unix(0, nsec)
+	if time.Since(ts) > 1*time.Second {
+		t.Errorf("Timestamp of check is %s but expected something very recent", ts)
+	}
+
+	// Make sure stored data are correct
+	testResults, err := specimen.Fetch(name)
+	if err != nil {
+		t.Fatalf("Could not fetch data, got: %v", err)
+	}
+	if len(testResults) != 1 {
+		t.Fatalf("StoreReader: expected length of []Result to be 1, but got %v", len(testResults))
+	}
+
+	if testResults[0].Title != results[0].Title {
+		t.Fatalf("Expected test result title to be '%s', but got '%s'", results[0].Title, testResults[0].Title)
+	}
+
+	// Make sure the check is not deleted after maintain with CheckExpiry == 0
+	if err := specimen.Maintain(); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if _, err := specimen.Fetch(name); err != nil {
+		t.Fatalf("Expected the check to be present in the DB, got: %v", err)
+	}
+
+	// Make sure the check is not deleted after maintain with CheckExpiry == 1 day
+	specimen.CheckExpiry = 24 * time.Hour
+	if err := specimen.Maintain(); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if _, err := specimen.Fetch(name); err != nil {
+		t.Fatalf("Expected the check to be present in the DB, got: %v", err)
+	}
+
+	// Make sure the check is deleted after maintain with CheckExpiry > 0
+	specimen.CheckExpiry = 1 * time.Nanosecond
+	if err := specimen.Maintain(); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if _, err := specimen.Fetch(name); err == nil {
+		t.Fatalf("Expected not to be able to fetch the result from the DB")
+	}
+}


### PR DESCRIPTION
Would you consider merging SQL storage?

This patchs adds a SQL storage implementation.
Only the sqlite3 is available, but any backend supported by the sqlx package should be easily added.