### PR TITLE
docs: bump golang version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ contribution. See the [DCO](DCO) file for details.
 
 ## Getting Started
 
-You'll need Go 1.7 or newer installed.
+You'll need Go 1.8 or newer installed.
 
 1. [Fork this repo](https://github.com/sourcegraph/checkup). This makes a copy of the code you can write to.
 2. If you don't already have this repo (sourcegraph/checkup.git) repo on your computer, get it with `go get github.com/sourcegraph/checkup/cmd/checkup`.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There are 3 components:
 $ go get -u github.com/sourcegraph/checkup/cmd/checkup
 ```
 
-You'll need Go 1.7 or newer. Verify it's installed properly:
+You'll need Go 1.8 or newer. Verify it's installed properly:
 
 ```bash
 $ checkup --help
@@ -441,6 +441,7 @@ Linux binary:
 ```bash
 git clone git@github.com:sourcegraph/checkup.git
 cd checkup
+docker pull golang:latest
 docker run --net=host --rm \ 
 -v `pwd`:/project \ 
 -w /project golang bash \ 


### PR DESCRIPTION
bump to 1.8 and increase chance of success for simpler docker example.

Fixes #75