### PR TITLE
Adding support for Host header on checks

### DIFF
--- a/httpchecker.go
+++ b/httpchecker.go
@@ -61,6 +61,10 @@ type HTTPChecker struct {
 	// used.
 	Client *http.Client `json:"-"`
 
+	// Host is the host to add to the request that is
+	// sent for the check
+	Host string `json:"host,omitempty"`
+
 	// Headers contains headers to added to the request
 	// that is sent for the check
 	Headers http.Header `json:"headers,omitempty"`
@@ -83,6 +87,10 @@ func (c HTTPChecker) Check() (Result, error) {
 	req, err := http.NewRequest("GET", c.URL, nil)
 	if err != nil {
 		return result, err
+	}
+
+	if c.Host != "" {
+		req.Host = c.Host
 	}
 
 	if c.Headers != nil {

--- a/httpchecker_test.go
+++ b/httpchecker_test.go
@@ -103,6 +103,18 @@ func TestHTTPChecker(t *testing.T) {
 		t.Errorf("Expected result.Down=%v, got %v", want, got)
 	}
 
+	// Test with a Host
+	hc.Host = "example.com/"
+	hc.MustContain = "Echo"
+	hc.ThresholdRTT = 0
+	result, err = hc.Check()
+	if err != nil {
+		t.Errorf("Didn't expect an error: %v", err)
+	}
+	if got, want := result.Down, true; got != want {
+		t.Errorf("Expected result.Down=%v, got %v", want, got)
+	}
+
 	// Test with a Header
 	hc.Headers = http.Header{
 		"X-Checkup": []string{"Echo"},


### PR DESCRIPTION
Was trying to use this to check services behind `Traefik`, and discovered that there wasn't a way to pass a `Host` header so just trying to contribute this back. Wanted to keep parity with how `Host` is special on `http.Request` so decided to not opt for parsing the header map for any `Host` header.