### PR TITLE
Update checkup.js

### DIFF
--- a/statuspage/js/checkup.js
+++ b/statuspage/js/checkup.js
@@ -81,14 +81,7 @@ checkup.makeTimeTag = function(ms) {
 	// dateTimeString converts ms (in milliseconds) into
 	// a value usable in a <time> tag's datetime attribute.
 	function dateTimeString(ms) {
-		var d = new Date(ms);
-		return d.getFullYear()+"-"
-			+ checkup.leftpad(d.getMonth()+1, 2, "0")+"-"
-			+ checkup.leftpad(d.getDate(), 2, "0")+"T"
-			+ checkup.leftpad(d.getHours(), 2, "0")+":"
-			+ checkup.leftpad(d.getMinutes(), 2, "0")+":"
-			+ checkup.leftpad(d.getSeconds(), 2, "0")+"-"
-			+ checkup.leftpad((d.getTimezoneOffset()/60), 2, "0")+":00";
+		return (new Date(ms)).toUTCString();
 	}
 
 	return '<time class="dynamic" datetime="'+dateTimeString(ms)+'">'


### PR DESCRIPTION
scripts: change the dateTimeString(ms) method

Currently there is a problem with the *Last check:* field if you are on a different timezone than GMT. The calculation way is wrong as you end up with a --<hours> causing the value to be NaN. Changed the function to return a UTC string date.

Fixes Last check field in the Status Page