### PR TITLE
Updating docs Go version to 1.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ contribution. See the [DCO](DCO) file for details.
 
 ## Getting Started
 
-You'll need Go 1.8 or newer installed.
+You'll need Go 1.10 or newer installed.
 
 1. [Fork this repo](https://github.com/sourcegraph/checkup). This makes a copy of the code you can write to.
 2. If you don't already have this repo (sourcegraph/checkup.git) repo on your computer, get it with `go get github.com/sourcegraph/checkup/cmd/checkup`.

--- a/README.md
+++ b/README.md
@@ -451,6 +451,24 @@ Uh oh, having some fires? 🔥 You can create a type that implements `checkup.No
 
 You can implement your own Checker and Storage types. If it's general enough, feel free to submit a pull request so others can use it too!
 
+### Building Locally
+
+Requires Go v1.10 or newer.
+
+```bash
+git clone git@github.com:sourcegraph/checkup.git
+cd checkup/cmd/checkup/
+
+# Install dependencies
+go get -v -d
+
+# Build binary
+go build -v -ldflags '-s' -o ../../checkup
+
+# Run tests
+go test -race ../../
+```
+
 ### Building with Docker
 
 Linux binary:


### PR DESCRIPTION
This PR updates the documentation to reflect the requirement of Golang v1.10, up from v1.8.

A recent attempt to build the project resulted in some errors:

```sh
$ go version 
go version go1.9.4 darwin/amd64

$ go build -v -ldflags '-s' -o ../../checkup
github.com/miekg/dns
# github.com/miekg/dns
../../../github.com/miekg/dns/dnssec_keyscan.go:290:7: undefined: strings.Builder
../../../github.com/miekg/dns/msg_helpers.go:271:8: undefined: strings.Builder
../../../github.com/miekg/dns/serve_mux.go:43:9: undefined: strings.Builder
../../../github.com/miekg/dns/types.go:440:10: undefined: strings.Builder
../../../github.com/miekg/dns/types.go:464:10: undefined: strings.Builder
../../../github.com/miekg/dns/types.go:492:10: undefined: strings.Builder
../../../github.com/miekg/dns/types.go:513:29: undefined: strings.Builder
../../../github.com/miekg/dns/types.go:523:28: undefined: strings.Builder
```

Searching [miekg/dns](https://github.com/miekg/dns) revealed https://github.com/miekg/dns/issues/940 in which the author recommends upgrading Go versions. This repo also notes that it aims to support the latest 2 versions of Go, which are currently 1.12 and 1.11.

Version 1.10 is the next closest version that builds successfully.