### PR TITLE
Automated Travis/Github releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,20 @@
 language: go
+if: NOT tag = master-auto
+before_deploy:
+  - cat PLATFORMS | xargs -L 1 -P 15 ./build-cross.sh
+  - git remote add gh https://${GITHUB_API_KEY}@github.com/${TRAVIS_REPO_SLUG}.git
+  - git fetch gh --tags
+  - git tag -f master-auto
+  - git push gh --tags -f
+  - git remote rm gh
+deploy:
+  provider: releases
+  api_key: $GITHUB_API_KEY
+  file_glob: true
+  file: "builds/*"
+  skip_cleanup: true
+  prerelease: true
+  overwrite: true
+  target_commitish: $TRAVIS_COMMIT
+  on:
+    branch: master

--- a/PLATFORMS
+++ b/PLATFORMS
@@ -1,0 +1,13 @@
+freebsd_386
+freebsd_amd64
+freebsd_arm7
+linux_386
+linux_amd64
+linux_arm64
+linux_arm7
+mac_amd64
+openbsd_386
+openbsd_amd64
+solaris_amd64
+windows_386
+windows_amd64

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://i.imgur.com/UWhSoQj.png" width="450" alt="Checkup">
 
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/sourcegraph/checkup) [![Sourcegraph](https://sourcegraph.com/github.com/sourcegraph/checkup/-/badge.svg)](https://sourcegraph.com/github.com/sourcegraph/checkup?badge)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/sourcegraph/checkup) [![Sourcegraph](https://sourcegraph.com/github.com/sourcegraph/checkup/-/badge.svg)](https://sourcegraph.com/github.com/sourcegraph/checkup?badge) [![TravisCI](https://api.travis-ci.org/sourcegraph/checkup.svg?branch=master)](https://travis-ci.org/sourcegraph/checkup/)
 
 
 **Checkup is distributed, lock-free, self-hosted health checks and status pages, written in Go.**
@@ -484,3 +484,37 @@ docker run --net=host --rm \
 ```
 
 This will create a checkup binary in the root project folder.
+
+### Building with the Cross-Compiler
+
+Alternative operating systems and architectures can be built using the [build-cross.sh](./build-cross.sh) script which will output binaries to `./builds/`. The build target can be passed in an `[OS]_[ARCH]` format:
+
+```sh
+./build-cross.sh linux_amd64
+./build-cross.sh freebsd_386
+
+ls -al builds/
+# checkup_freebsd_386
+# checkup_linux_amd64
+```
+
+Multiple platforms can be built in parallel by sending the contents of [PLATFORMS](./PLATFORMS) to the [build-cross.sh](./build-cross.sh) script:
+
+```sh
+# -P 15 : run a max of 15 processes simultaneously
+cat PLATFORMS | xargs -L 1 -P 15 ./build-cross.sh
+
+ls -al builds/
+# checkup_freebsd_386
+# checkup_freebsd_amd64
+# checkup_linux_386
+# checkup_linux_amd64
+# checkup_linux_arm64
+# checkup_openbsd_386
+# checkup_openbsd_amd64
+# checkup_solaris_amd64
+```
+
+### Builds via Travis CI
+
+Automated builds happen in [Travis CI](https://travis-ci.org/sourcegraph/checkup/) each time `master` branch is updated. See the latest prerelease at [sourcegraph/checkup/releases](https://github.com/sourcegraph/checkup/releases).

--- a/build-cross.sh
+++ b/build-cross.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Cross-compiles the project for several platforms.
+# Outputs to ./builds/
+#
+# Single-run usage:
+#   ./build-cross.sh linux_amd64
+#   
+# Parallel usage:
+#   cat PLATFORMS | xargs -L 1 -P 8 ./build-cross.sh
+
+if [ -z "$1" ]; then
+  echo "Error: Specify a platform"
+  exit 1
+fi
+
+echo Building platform \"$1\" ...
+
+mkdir -p ./builds/
+pushd ./cmd/checkup/ > /dev/null 2>&1
+
+OS=$(echo $1 | cut -d'_' -f1)
+ARCH=$(echo $1 | cut -d'_' -f2)
+GOOS=$OS GOARCH=$ARCH go build -v -ldflags '-s' -o "../../builds/checkup_$1" > /dev/null 2>&1
+
+echo Completed platform \"$1\"
+popd > /dev/null 2>&1


### PR DESCRIPTION
## What?

This pull request enables automated Travis/Github pre-releases for `master` branch.

The following configuration proposal deploys `master` branch changes to a Github pre-release tagged as `master-auto`. This `master-auto` tag is reused for each future deploy, preventing tag buildup. Releases are overwritten, preventing release buildup.


## Why?

A quick look through the project issues reveals a few tickets that could be assisted or avoided with more frequent releases:

- https://github.com/sourcegraph/checkup/issues/29
- https://github.com/sourcegraph/checkup/issues/37
- https://github.com/sourcegraph/checkup/issues/45
- https://github.com/sourcegraph/checkup/issues/52
- https://github.com/sourcegraph/checkup/issues/67
- https://github.com/sourcegraph/checkup/issues/84

Travis CI is capable of deploying anywhere, but since Github releases are already in use it makes sense to keep these artifacts in the same spot.


## How?

Releases can be automated by extending the `.travis.yml` file. This pull request includes a few files:

- `.travis.yml`: Implements auto pre-release on `master` branch changes
- `PLATFORMS`: List of `[OS]_[ARCH]` used to create binaries
- `README.md`: Updated docs
- `build-cross.sh`: A cross-compiler assistant script, used manually and in Travis CI

The `.travis.yml` config contains some notable features:

- `if: NOT tag = master-auto`: Don't need to re-run test & deploy on `master-auto` tag updates, since they've already been done on the origin branch of `master`
- `build-cross.sh` is run with a max of 15 processes to enable simultaneous cross-platform compilation 🚄
- `skip_cleanup: true`: needed to ensure `builds/*` binaries can be uploaded as part of the release
`target_commitish: $TRAVIS_COMMIT`: needed to ensure Travis releases with the right commit ID, otherwise releases are made titled "untagged-xxxxx"


## Example

This proposal was tested on a fork. The output can be previewed at:

- Repo: https://github.com/emcniece/checkup
- Releases: https://github.com/emcniece/checkup/releases
- Travis: https://travis-ci.org/emcniece/checkup/

The emcniece/checkup/releases page linked here contains some other release naming patterns tested during the development of this feature. They ended up being pretty messy, so the `master-auto` overwrite pattern was chosen.


## Alternatives

Though this `master-auto` tag update & overwrite pattern reduces tag and release clutter, there are drawbacks: Github doesn't always place this release at the very top of the release list each time it updates. Travis also seems to have the occasional problem with overwriting binaries during the deploy upload process - the release is still made and most binaries are uploaded, but if one upload fails it will not be included in the downloadable assets from the Github release page.

These problems can be avoided by making unique tags and releases. This results in a release for each `master` branch commit.

To do this, the `.travis.yml` config can be simplified:

```yml
language: go
if: NOT tag = master-auto
before_deploy:
  - cat PLATFORMS | xargs -L 1 -P 15 ./build-cross.sh
  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
  - git tag $TRAVIS_TAG
deploy:
  provider: releases
  api_key: $GITHUB_API_KEY
  file_glob: true
  file: "builds/*"
  skip_cleanup: true
  prerelease: true
  on:
    branch: master
```

This will create releases with the name of `$TRAVIS_TAG`, which works out to something like `20190505002539-0fa1a97`.

A simpler tag could also be used, like `auto-$(git log --format=%h -1)}`.


## Implementation Preparation

If you like this idea and want to merge, there is some quick credential setup that needs to happen: a Github token must be created and added to the Travis environment variables.

### 1. Create Github Token

1. Browse to https://github.com/settings/tokens
1. Generate a new token, give it a name
1. Check a single box: the `public_repo` scope
1. Click "Generate Token"
1. Copy token for use in next steps

### 2. Populate Travis CI ENV

1. Visit https://travis-ci.org/sourcegraph/checkup/settings
1. Under the "Environment Variables" section, add:
    - Name: `GITHUB_API_KEY`
    - Value: [token from step 1]
    - Display value in build log: OFF
1. Click "Add"


## References

- [Configuring encrypted Travis tokens](https://stackoverflow.com/a/33109519/943540)
- [Release overwrite example](https://github.com/oliexdev/openScale/pull/121)
