### PR TITLE
scripts: add timestamp to bust the cache to retrieve latest updates

### DIFF
--- a/statuspage/js/fs.js
+++ b/statuspage/js/fs.js
@@ -14,7 +14,7 @@ checkup.storage = (function() {
 	// download.
 	function getCheckFileList(timeframe, callback) {
 		var after = time.Now() - timeframe;
-		checkup.getJSON(url+'/index.json', function(index) {
+		checkup.getJSON(url+'/index.json?t=' + Date.now(), function(index) {
 			var names = [];
 			for (var name in index) {
 				if (index[name] >= after) {


### PR DESCRIPTION
On GitHub Pages the files are often so good cached that old / stale data
is still retrieved and not the latest version of `index.json`.

Even a reload with the "disable cache" option enabled in the network
settings of the browser developer tools does not help in most cases.

Thus we have to bust the cache for every load by adding a timestamp in
this case.

There are also other solutions but these would affect all AJAX calls and
this solution busts the cache for only the `index.json` file.

This PR closes #117 