### PR TITLE
add DCO file for external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,8 @@ contribution accepted.
 
 By contributing to this project you agree to the [Developer Certificate of Origin
 (DCO)](https://developercertificate.org/). This document was created by the Linux Kernel community
-and is a simple statement that you, as a contributor, have the legal right to make the contribution.
+and is a simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
 
 ## Getting Started
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
We currently ask external contributors to sign a CLA, but many open-source projects opt for a DCO instead (e.g., https://about.gitlab.com/blog/2017/11/01/gitlab-switches-to-dco-license/).

This adds a DCO to this repository, which will allow us to merge PRs from external contributors without first asking them to sign a CLA.