### PR TITLE
Adds Optional SQLite Docker 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+builds
+checks
+checkup.json

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ test-%:
 
 docker:
 	docker build --no-cache . -t $(DOCKER_IMAGE)
+
+docker_sqlite:
+	docker build --no-cache -t $(DOCKER_IMAGE):sqlite3 -f sqlite3.Dockerfile .

--- a/docker-compose.sqlite3.yml
+++ b/docker-compose.sqlite3.yml
@@ -1,0 +1,28 @@
+version: "2.4"
+
+services:
+  #-- worker node
+  worker:
+    image: checkup:sqlite3
+    volumes:
+      - ./checkup.json:/app/checkup.json
+      - ./checks:/app/checks
+    entrypoint:
+      - checkup
+      - every
+      - 10s
+    user: "1000:1000"
+    restart: always
+
+  #-- client
+  checkup:
+    hostname: checkup
+    image: checkup:sqlite3
+    ports:
+      - 3000:3000
+    volumes:
+      - ./checkup.json:/app/checkup.json
+      - ./checks:/app/checks
+      - ./statuspage/js/config_sqlite3.js:/app/statuspage/js/config.js
+    user: "1000:1000"
+    restart: always

--- a/sqlite3.Dockerfile
+++ b/sqlite3.Dockerfile
@@ -1,0 +1,33 @@
+#---------------------------- Build 
+FROM golang:1.14-alpine as builder
+
+COPY . /app
+WORKDIR /app
+RUN apk add --no-cache make gcc musl-dev && \
+    rm -rf /var/cache/apk/* && \
+    make build-sqlite3
+
+#---------------------------- Deploy 
+FROM alpine:3.4
+
+RUN apk --update upgrade && \
+    apk add --no-cache sqlite ca-certificates && \
+    rm -f /usr/bin/sqlite3 && \
+    rm -rf /var/cache/apk/*
+
+RUN mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+WORKDIR /app
+
+COPY --from=builder /app/builds/checkup /usr/local/bin/checkup
+ADD statuspage/ /app/statuspage
+
+RUN addgroup -g 1000 app 
+RUN adduser -g "" -G app -D -H -u 1000 app 
+
+USER app
+
+EXPOSE 3000
+ENTRYPOINT ["checkup"]
+CMD ["serve"]

--- a/statuspage/js/config_sqlite3.js
+++ b/statuspage/js/config_sqlite3.js
@@ -1,0 +1,28 @@
+checkup.config = {
+	// How much history to show on the status page. Long durations and
+	// frequent checks make for slow loading, so be conservative.
+	// This value is in NANOSECONDS to mirror Go's time package.
+	"timeframe": 1 * time.Day,
+
+	// How often, in seconds, to pull new checks and update the page.
+	"refresh_interval": 60,
+
+	// Configure read-only access to stored checks. This configuration
+	// depends on your storage provider. Any credentials and other values
+	// here will be visible to everyone, so use keys with ONLY read access!
+	"storage": {
+		// Storage type (fs for local, s3 for AWS S3)
+		"type": "sqlite3",
+		// Local checkup server by default, set to github page if
+		// you're hosting your status page on GitHub.
+		// e.g. "https://sourcegraph.github.io/checkup/checks/"
+		"url": "/"
+	},
+
+	// The text to display along the top bar depending on overall status.
+	"status_text": {
+		"healthy": "Situation Normal",
+		"degraded": "Degraded Service",
+		"down": "Service Disruption"
+	}
+};


### PR DESCRIPTION
This PR allows opt-in SQLite support with different build/run commands. 

usage: 
- build checkup:sqlite3 with `make docker_sqlite` 
- start stack with `docker-compose -f docker-compose.sqlite3.yml` 

The d/c stack includes a separate worker, allowing its own entrypoint directive. eg: `checkup every 10s`, independent of the frontend.   
A sqlite config.js is bind-mounted from `./statuspage/js/config_sqlite3.js`

The built docker image _is_ larger: 155MB vs the fs-only image's 33.4 MB. 

 This is to address #140 