### PR TITLE
Remove use of ioutil package

### DIFF
--- a/check/http/http.go
+++ b/check/http/http.go
@@ -3,7 +3,6 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
@@ -199,7 +198,7 @@ func (c Checker) checkDown(resp *http.Response) error {
 	if c.MustContain == "" && c.MustNotContain == "" {
 		return nil
 	}
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("reading response body: %w", err)
 	}

--- a/check/tcp/tcp.go
+++ b/check/tcp/tcp.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"time"
 
@@ -109,7 +108,7 @@ func (c Checker) doChecks() types.Attempts {
 			var tlsConfig tls.Config
 			tlsConfig.InsecureSkipVerify = c.TLSSkipVerify
 			if c.TLSCAFile != "" {
-				rootPEM, err := ioutil.ReadFile(c.TLSCAFile)
+				rootPEM, err := os.ReadFile(c.TLSCAFile)
 				if err != nil || rootPEM == nil {
 					return nil, errReadingRootCert
 				}

--- a/check/tls/tls.go
+++ b/check/tls/tls.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"time"
 
@@ -92,7 +91,7 @@ func (c Checker) Check() (types.Result, error) {
 			c.tlsConfig.RootCAs = x509.NewCertPool()
 		}
 		for _, fname := range c.TrustedRoots {
-			pemData, err := ioutil.ReadFile(fname)
+			pemData, err := os.ReadFile(fname)
 			if err != nil {
 				return types.Result{}, fmt.Errorf("error loading file: %w", err)
 			}

--- a/checkup_test.go
+++ b/checkup_test.go
@@ -3,7 +3,6 @@ package checkup
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -182,7 +181,7 @@ func TestJSON(t *testing.T) {
 		testConfig = "testdata/config.json"
 	)
 
-	jsonBytes, err := ioutil.ReadFile(testConfig)
+	jsonBytes, err := os.ReadFile(testConfig)
 	if err != nil {
 		t.Fatalf("Error reading config file: %s", testConfig)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -67,7 +66,7 @@ store the results of the check, use --store.`,
 }
 
 func loadCheckup() checkup.Checkup {
-	configBytes, err := ioutil.ReadFile(configFile)
+	configBytes, err := os.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/notifier/discord/discord.go
+++ b/notifier/discord/discord.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -97,7 +96,7 @@ func (s Notifier) Send(result types.Result) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Println("discord: error reading response body", err)
 		}

--- a/storage/appinsights/appinsights_test.go
+++ b/storage/appinsights/appinsights_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -126,7 +125,7 @@ func setup(delay time.Duration, retries int, interval int, timeout int, results 
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(fmt.Sprintf("gzip NewReader: %v", err)))
 		}
-		b, _ := ioutil.ReadAll(req)
+		b, _ := io.ReadAll(req)
 		parsed, err := parsePayload(b)
 		for i, j := range parsed {
 			data := j["data"].(map[string]interface{})

--- a/storage/fs/fs.go
+++ b/storage/fs/fs.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -125,7 +124,7 @@ func (fs Storage) Maintain() error {
 		return nil
 	}
 
-	files, err := ioutil.ReadDir(fs.Dir)
+	files, err := os.ReadDir(fs.Dir)
 	if err != nil {
 		return err
 	}

--- a/storage/fs/fs_test.go
+++ b/storage/fs/fs_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ func TestStorage(t *testing.T) {
 	results := []types.Result{{Title: "Testing"}}
 	resultsBytes := []byte(`[{"title":"Testing"}]` + "\n")
 
-	dir, err := ioutil.TempDir("", "checkup")
+	dir, err := os.MkdirTemp("", "checkup")
 	if err != nil {
 		t.Fatalf("Cannot create temporary directory: %v", err)
 	}
@@ -54,7 +53,7 @@ func TestStorage(t *testing.T) {
 
 	// Make sure check file bytes are correct
 	checkfile := filepath.Join(specimen.Dir, name)
-	b, err := ioutil.ReadFile(checkfile)
+	b, err := os.ReadFile(checkfile)
 	if err != nil {
 		t.Fatalf("Expected no error reading body, got: %v", err)
 	}

--- a/storage/s3/s3_test.go
+++ b/storage/s3/s3_test.go
@@ -2,7 +2,6 @@ package s3
 
 import (
 	"bytes"
-	"io/ioutil"
 	"strconv"
 	"strings"
 	"testing"
@@ -73,7 +72,7 @@ func TestS3Store(t *testing.T) {
 	}
 
 	// Make sure body bytes are correct
-	bodyBytes, err := ioutil.ReadAll(fakes3.input.Body)
+	bodyBytes, err := io.ReadAll(fakes3.input.Body)
 	if err != nil {
 		t.Fatalf("Expected no error reading body, got: %v", err)
 	}

--- a/storage/sql/sql_test.go
+++ b/storage/sql/sql_test.go
@@ -3,7 +3,6 @@
 package sql
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ func TestSQL(t *testing.T) {
 	results := []types.Result{{Title: "Testing"}}
 
 	// Create temporary directory for the tests
-	dir, err := ioutil.TempDir("", "checkup")
+	dir, err := os.MkdirTemp("", "checkup")
 	if err != nil {
 		t.Fatalf("Cannot create temporary directory: %v", err)
 	}

--- a/storage/sqlite3/sqlite_test.go
+++ b/storage/sqlite3/sqlite_test.go
@@ -3,7 +3,6 @@
 package sqlite3
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ func TestSQL(t *testing.T) {
 	results := []types.Result{{Title: "Testing"}}
 
 	// Create temporary directory for the tests
-	dir, err := ioutil.TempDir("", "checkup")
+	dir, err := os.MkdirTemp("", "checkup")
 	if err != nil {
 		t.Fatalf("Cannot create temporary directory: %v", err)
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)