### PR TITLE
Replacing fmt.Sprintf with strconv.Itoa

### DIFF
--- a/storage/appinsights/appinsights.go
+++ b/storage/appinsights/appinsights.go
@@ -136,7 +136,7 @@ func (c Storage) send(conclude types.Result) {
 	availability := appinsights.NewAvailabilityTelemetry(conclude.Title, stats.Mean, conclude.Healthy)
 	availability.RunLocation = c.TestLocation
 	availability.Message = message
-	availability.Id = fmt.Sprintf("%d", conclude.Timestamp)
+	availability.Id = strconv.Itoa(conclude.Timestamp)
 	for i := 0; i < len(conclude.Times); i++ {
 		k := strconv.Itoa(i)
 		availability.GetMeasurements()[k] = float64(conclude.Times[i].RTT)


### PR DESCRIPTION
This campiagn replaces `fmt.Sprintf` with `strconv.Itoa`

[_Created by Sourcegraph batch change `david.rohnow/comby-go-fmt`._](https://demo.sourcegraph.com/users/david.rohnow/batch-changes/comby-go-fmt)