### PR TITLE
storage/github: add commit_message_suffix as config entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,15 @@ To serve files for your status page from S3, copy `statuspage/config_s3.js` over
     "committer_name": "Commiter Name",
     "committer_email": "you@example.com",
     "branch": "gh-pages",
-    "dir": "updates"
+    "dir": "updates",
+    "commit_message_suffix": "[ci skip]"
 }
 ```
 
-Where "dir" is a subdirectory within the repo to push all the check files. Setup instructions:
+- "dir" is a subdirectory within the repo to push all the check files
+- "commit_message_suffix" is appended to each commit message (default: "[ci skip]", to remove set to " " (single space))
+
+Setup instructions:
 
 1. Create a repository,
 2. Copy the contents of `statuspage/` from this repo to the root of your new repo,

--- a/storage/github/github_test.go
+++ b/storage/github/github_test.go
@@ -98,6 +98,10 @@ func withGitHubServer(t *testing.T, specimen Storage, f func(*github.Client)) {
 		LastUpdated: time.Now().UnixNano(),
 		Files:       map[string]bool{},
 	}
+	gitCommitMessageSuffix := specimen.CommitMessageSuffix
+	if gitCommitMessageSuffix == "" {
+		gitCommitMessageSuffix = defaultCommitMessageSuffix
+	}
 
 	fixtureFiles := []string{"1501523631505010894-check.json", "1501525202306053005-check.json", "index.json"}
 	for _, file := range fixtureFiles {
@@ -175,7 +179,7 @@ func withGitHubServer(t *testing.T, specimen Storage, f func(*github.Client)) {
 			if err := json.NewDecoder(r.Body).Decode(&stuff); err != nil {
 				t.Errorf("Expected body to decode fine, but got %+v", err)
 			}
-			if expected := fmt.Sprintf("[checkup] store %s [ci skip]", strings.TrimPrefix(path, "/")); stuff.Message != expected {
+			if expected := fmt.Sprintf("[checkup] store %s %s", strings.TrimPrefix(path, "/"), gitCommitMessageSuffix); stuff.Message != expected {
 				t.Errorf("Expected commit message '%s', got '%s'", expected, stuff.Message)
 			}
 			if stuff.SHA != serverSHAForRepo {
@@ -222,7 +226,7 @@ func withGitHubServer(t *testing.T, specimen Storage, f func(*github.Client)) {
 			if err := json.NewDecoder(r.Body).Decode(&stuff); err != nil {
 				t.Errorf("Expected body to decode fine, but got %+v", err)
 			}
-			if expected := fmt.Sprintf("[checkup] store %s [ci skip]", strings.TrimPrefix(path, "/")); stuff.Message != expected {
+			if expected := fmt.Sprintf("[checkup] store %s %s", strings.TrimPrefix(path, "/"), gitCommitMessageSuffix); stuff.Message != expected {
 				t.Errorf("Expected commit message '%s', got '%s'", expected, stuff.Message)
 			}
 			if stuff.SHA != "" {
@@ -255,7 +259,7 @@ func withGitHubServer(t *testing.T, specimen Storage, f func(*github.Client)) {
 			if err := json.NewDecoder(r.Body).Decode(&stuff); err != nil {
 				t.Errorf("Expected body to decode fine, but got %+v", err)
 			}
-			if expected := fmt.Sprintf("[checkup] delete %s [ci skip]", strings.TrimPrefix(path, "/")); stuff.Message != expected {
+			if expected := fmt.Sprintf("[checkup] delete %s %s", strings.TrimPrefix(path, "/"), gitCommitMessageSuffix); stuff.Message != expected {
 				t.Errorf("Expected commit message to be '%s', got '%s'", expected, stuff.Message)
 			}
 			if stuff.SHA != sha(resultsBytes) {
@@ -301,12 +305,13 @@ func withGitHubServer(t *testing.T, specimen Storage, f func(*github.Client)) {
 func TestGitHubWithoutSubdir(t *testing.T) {
 	// Our subject, our specimen.
 	specimen := &Storage{
-		RepositoryOwner: "o",
-		RepositoryName:  "r",
-		CommitterName:   "John Appleseed",
-		CommitterEmail:  "appleseed@example.org",
-		Branch:          "b",
-		Dir:             "",
+		RepositoryOwner:     "o",
+		RepositoryName:      "r",
+		CommitterName:       "John Appleseed",
+		CommitterEmail:      "appleseed@example.org",
+		Branch:              "b",
+		Dir:                 "",
+		CommitMessageSuffix: "",
 	}
 
 	withGitHubServer(t, *specimen, func(client *github.Client) {
@@ -374,12 +379,13 @@ func TestGitHubWithoutSubdir(t *testing.T) {
 func TestGitHubWithSubdir(t *testing.T) {
 	// Our subject, our specimen.
 	specimen := &Storage{
-		RepositoryOwner: "o",
-		RepositoryName:  "r",
-		CommitterName:   "John Appleseed",
-		CommitterEmail:  "appleseed@example.org",
-		Branch:          "b",
-		Dir:             "subdir/",
+		RepositoryOwner:     "o",
+		RepositoryName:      "r",
+		CommitterName:       "John Appleseed",
+		CommitterEmail:      "appleseed@example.org",
+		Branch:              "b",
+		Dir:                 "subdir/",
+		CommitMessageSuffix: "foo bar",
 	}
 
 	withGitHubServer(t, *specimen, func(client *github.Client) {


### PR DESCRIPTION
Adding '[ci skip]' made sense in the original implementation, when CI
was not often used to act on a status repo. In the age of GitHub
Actions, it would be helpful to be able to control whether this string
is appended.

The current implementation gives the user the choice to append it by
setting the `"commit_message_suffix": "[ci skip]"` field to their
configuration, but leaves it off by default.