### PR TITLE
github: make it a Maintainer

### DIFF
--- a/storage/github/github.go
+++ b/storage/github/github.go
@@ -295,7 +295,7 @@ func (gh *Storage) GetIndex() (map[string]int64, error) {
 }
 
 // Maintain deletes check files that are older than gh.CheckExpiry.
-func (gh *Storage) Maintain() error {
+func (gh Storage) Maintain() error {
 	if gh.CheckExpiry == 0 {
 		return nil
 	}


### PR DESCRIPTION
In order to be a Maintainer, the GitHub Storage implementation must respond to `Maintain()`. Unlike all the other implementations, the GitHub implementation's Maintain() method was on the pointer receiver. This fix should allow the GitHub Storage implementation to be a Maintainer.

As a side note, it'd be nice to have a setting for this somewhere in case someone wants to keep all their history.